### PR TITLE
[Design/groomer] 미용사 견적서 리스트 UI 구현 #42

### DIFF
--- a/apps/groomer/next.config.mjs
+++ b/apps/groomer/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  transpilePackages: ['@daengle/services'], // 모노레포의 공통 패키지 추가
+  transpilePackages: ['@daengle/services'],
 };
 
 export default nextConfig;

--- a/apps/groomer/next.config.mjs
+++ b/apps/groomer/next.config.mjs
@@ -1,4 +1,7 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ['@daengle/services'], // 모노레포의 공통 패키지 추가
+};
 
 export default nextConfig;

--- a/apps/groomer/pages/sheet-list/index.tsx
+++ b/apps/groomer/pages/sheet-list/index.tsx
@@ -1,0 +1,9 @@
+import { SheetList } from '@daengle/services';
+
+export default function List() {
+  return (
+    <div>
+      <SheetList />
+    </div>
+  );
+}

--- a/apps/groomer/pages/sheet-list/index.tsx
+++ b/apps/groomer/pages/sheet-list/index.tsx
@@ -1,9 +1,0 @@
-import { SheetList } from '@daengle/services';
-
-export default function List() {
-  return (
-    <div>
-      <SheetList />
-    </div>
-  );
-}

--- a/apps/groomer/src/pages/sheet-list/index.tsx
+++ b/apps/groomer/src/pages/sheet-list/index.tsx
@@ -1,0 +1,9 @@
+import { SheetList } from '@daengle/services';
+
+export default function List() {
+  return (
+    <div>
+      <SheetList />
+    </div>
+  );
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,0 +1,1 @@
+export { default as SheetList } from './sheet/components/sheet-list/index';

--- a/packages/services/src/sheet/components/sheet-list/index.styles.ts
+++ b/packages/services/src/sheet/components/sheet-list/index.styles.ts
@@ -1,0 +1,185 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+
+const wrapper = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  max-width: 852px;
+  width: 100%;
+  height: 100vh;
+  margin: 0 auto;
+  background-color: #f9fafb;
+`;
+
+const headerContainer = css`
+  padding: 18px;
+  font-size: 24px;
+  font-weight: 600;
+  margin-top: 20px;
+`;
+
+const tabContainer = css`
+  display: flex;
+  padding: 18px 18px 0px 18px;
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 18px;
+    right: 18px;
+    height: 0.5px;
+    background-color: #d9d9d9;
+  }
+`;
+
+const tab = css`
+  font-size: 16px;
+  padding: 4px 13px 12px;
+  border: none;
+  background: none;
+  color: #d9d9d9;
+  cursor: pointer;
+  transition: color 0.3s;
+
+  &:hover {
+    color: #000000;
+  }
+`;
+
+const activeTab = css`
+  color: #000000;
+  border-bottom: 2px solid #000000;
+`;
+
+const listContainer = css`
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 18px 12px 0px;
+`;
+
+const card = css`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  align-items: stretch;
+  padding: 20px 24px;
+  margin-bottom: 12px;
+  background-color: #ffffff;
+  border-top-right-radius: 65.6px;
+  border-bottom-right-radius: 65.6px;
+`;
+
+const contentContainer = css`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 15px;
+`;
+
+const detailContainer = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 0 0 auto;
+`;
+
+const cardHeader = css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const cardContent = css`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const profileImage = css`
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+const name = css`
+  font-size: 1rem;
+  font-weight: bold;
+`;
+
+const type = css`
+  font-size: 9px;
+  padding: 2px 7px;
+  border-radius: 14.03px;
+  font-weight: bold;
+`;
+
+const general = css`
+  background-color: #eefffd;
+  color: #81d9d0;
+  border: #81d9d0 solid 0.5px;
+`;
+
+const designated = css`
+  background-color: #fffcf3;
+  color: #ffc748;
+  border: #ffc748 solid 0.5px;
+`;
+
+const details = css`
+  font-size: 16px;
+  color: #000000;
+  font-weight: 600;
+  margin: 0;
+`;
+
+const detailsNot = css`
+  color: #d9d9d9;
+`;
+
+const date = css`
+  font-size: 12px;
+  color: #979797;
+  margin: 0;
+`;
+
+const detailButton = css`
+  font-size: 10px;
+  color: #d9d9d9;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color 0.3s;
+
+  &:hover {
+    color: #000000;
+  }
+`;
+
+const styles = {
+  wrapper,
+  headerContainer,
+  tabContainer,
+  tab,
+  activeTab,
+  listContainer,
+  card,
+  contentContainer,
+  detailContainer,
+  profileImage,
+  cardContent,
+  cardHeader,
+  name,
+  type,
+  general,
+  designated,
+  details,
+  detailsNot,
+  date,
+  detailButton,
+};
+
+export default styles;

--- a/packages/services/src/sheet/components/sheet-list/index.styles.ts
+++ b/packages/services/src/sheet/components/sheet-list/index.styles.ts
@@ -1,4 +1,3 @@
-/** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 
 const wrapper = css`
@@ -62,7 +61,6 @@ const listContainer = css`
 const card = css`
   display: flex;
   flex-direction: row;
-  align-items: flex-start;
   align-items: stretch;
   padding: 20px 24px;
   margin-bottom: 12px;

--- a/packages/services/src/sheet/components/sheet-list/index.styles.ts
+++ b/packages/services/src/sheet/components/sheet-list/index.styles.ts
@@ -42,7 +42,6 @@ const tab = css`
   background: none;
   color: #d9d9d9;
   cursor: pointer;
-  transition: color 0.3s;
 
   &:hover {
     color: #000000;
@@ -106,8 +105,8 @@ const profileImage = css`
 `;
 
 const name = css`
-  font-size: 1rem;
-  font-weight: bold;
+  font-size: 14px;
+  font-weight: 600;
 `;
 
 const type = css`
@@ -152,7 +151,6 @@ const detailButton = css`
   background: none;
   border: none;
   cursor: pointer;
-  transition: color 0.3s;
 
   &:hover {
     color: #000000;

--- a/packages/services/src/sheet/components/sheet-list/index.tsx
+++ b/packages/services/src/sheet/components/sheet-list/index.tsx
@@ -1,10 +1,9 @@
-/** @jsxImportSource @emotion/react */
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import styles from './index.styles';
 // import NavBar from '../components/NavBar'; // 하단 네비게이션 바 컴포넌트
 
-interface SheetCardProps {
+interface Props {
   profileImage: string;
   name: string;
   type: '일반' | '지정';
@@ -12,7 +11,7 @@ interface SheetCardProps {
   date: string;
 }
 
-const sheetData: SheetCardProps[] = [
+const sheetData: Props[] = [
   {
     profileImage: 'https://via.placeholder.com/40',
     name: '미꼬누나',
@@ -83,13 +82,14 @@ export default function SheetList(): JSX.Element {
       <div css={styles.listContainer}>
         {filteredData.map((data, index) => (
           <SheetCard key={index} {...data} />
+          /* API 연동 후 key 고유 id값으로 변경 */
         ))}
       </div>
     </div>
   );
 }
 
-function SheetCard({ profileImage, name, type, details, date }: SheetCardProps): JSX.Element {
+function SheetCard({ profileImage, name, type, details, date }: Props): JSX.Element {
   const router = useRouter();
 
   const handleDetailClick = () => {

--- a/packages/services/src/sheet/components/sheet-list/index.tsx
+++ b/packages/services/src/sheet/components/sheet-list/index.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @emotion/react */
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import styles from './index.styles';

--- a/packages/services/src/sheet/components/sheet-list/index.tsx
+++ b/packages/services/src/sheet/components/sheet-list/index.tsx
@@ -1,0 +1,102 @@
+/** @jsxImportSource @emotion/react */
+import styles from './index.styles';
+// import NavBar from '../components/NavBar'; // 하단 네비게이션 바 컴포넌트
+
+interface SheetCardProps {
+  profileImage: string;
+  name: string;
+  type: '일반' | '지정';
+  details: string;
+  date: string;
+}
+
+const sheetData: SheetCardProps[] = [
+  {
+    profileImage: 'https://via.placeholder.com/40',
+    name: '미꼬누나',
+    type: '일반', // 리터럴 타입 "일반"
+    details: '노견, 슬개골 탈구',
+    date: '2024. 11. 18(수) · 11:00',
+  },
+  {
+    profileImage: 'https://via.placeholder.com/40',
+    name: '꼬미누나',
+    type: '지정', // 리터럴 타입 "지정"
+    details: '특이사항 없음',
+    date: '2024. 11. 18(수) · 11:00',
+  },
+  {
+    profileImage: 'https://via.placeholder.com/40',
+    name: '꼬미누나',
+    type: '지정', // 리터럴 타입 "지정"
+    details: '특이사항 없음',
+    date: '2024. 11. 18(수) · 11:00',
+  },
+  {
+    profileImage: 'https://via.placeholder.com/40',
+    name: '꼬미누나',
+    type: '지정', // 리터럴 타입 "지정"
+    details: '특이사항 없음',
+    date: '2024. 11. 18(수) · 11:00',
+  },
+  {
+    profileImage: 'https://via.placeholder.com/40',
+    name: '꼬미누나',
+    type: '지정', // 리터럴 타입 "지정"
+    details: '특이사항 없음',
+    date: '2024. 11. 18(수) · 11:00',
+  },
+  {
+    profileImage: 'https://via.placeholder.com/40',
+    name: '꼬미누나',
+    type: '지정', // 리터럴 타입 "지정"
+    details: '특이사항 없음',
+    date: '2024. 11. 18(수) · 11:00',
+  },
+];
+
+export default function SheetList(): JSX.Element {
+  return (
+    <div css={styles.wrapper}>
+      <header css={styles.headerContainer}>견적</header>
+      <div css={styles.tabContainer}>
+        <button css={[styles.tab, styles.activeTab]}>전체 견적서</button>
+        <button css={styles.tab}>지정 견적서</button>
+      </div>
+      <div css={styles.listContainer}>
+        {sheetData.map((data, index) => (
+          <SheetCard key={index} {...data} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SheetCard({ profileImage, name, type, details, date }: SheetCardProps): JSX.Element {
+  return (
+    <div css={styles.card}>
+      {/* contentContainer */}
+      <div css={styles.contentContainer}>
+        {/* Header */}
+        <div css={styles.cardHeader}>
+          <img src={profileImage} alt={`${name} 프로필`} css={styles.profileImage} />
+          <span css={styles.name}>{name}</span>
+          <span css={[styles.type, type === '지정' ? styles.designated : styles.general]}>
+            {type}
+          </span>
+        </div>
+
+        {/* Content */}
+        <div css={styles.cardContent}>
+          <p css={[styles.details, details === '특이사항 없음' && styles.detailsNot]}>{details}</p>
+          <p css={styles.date}>{date}</p>
+        </div>
+      </div>
+
+      {/* detailContainer */}
+      <div css={styles.detailContainer}>
+        <button css={styles.detailButton}>자세히 보기 &gt;</button>
+      </div>
+    </div>
+  );
+}

--- a/packages/services/src/sheet/components/sheet-list/index.tsx
+++ b/packages/services/src/sheet/components/sheet-list/index.tsx
@@ -1,4 +1,6 @@
 /** @jsxImportSource @emotion/react */
+import { useRouter } from 'next/router';
+import { useState } from 'react';
 import styles from './index.styles';
 // import NavBar from '../components/NavBar'; // 하단 네비게이션 바 컴포넌트
 
@@ -14,57 +16,72 @@ const sheetData: SheetCardProps[] = [
   {
     profileImage: 'https://via.placeholder.com/40',
     name: '미꼬누나',
-    type: '일반', // 리터럴 타입 "일반"
+    type: '일반',
     details: '노견, 슬개골 탈구',
     date: '2024. 11. 18(수) · 11:00',
   },
   {
     profileImage: 'https://via.placeholder.com/40',
     name: '꼬미누나',
-    type: '지정', // 리터럴 타입 "지정"
+    type: '지정',
     details: '특이사항 없음',
     date: '2024. 11. 18(수) · 11:00',
   },
   {
     profileImage: 'https://via.placeholder.com/40',
     name: '꼬미누나',
-    type: '지정', // 리터럴 타입 "지정"
+    type: '지정',
+    details: '대형견',
+    date: '2024. 11. 18(수) · 11:00',
+  },
+  {
+    profileImage: 'https://via.placeholder.com/40',
+    name: '꼬미누나',
+    type: '일반',
     details: '특이사항 없음',
     date: '2024. 11. 18(수) · 11:00',
   },
   {
     profileImage: 'https://via.placeholder.com/40',
     name: '꼬미누나',
-    type: '지정', // 리터럴 타입 "지정"
+    type: '일반',
     details: '특이사항 없음',
     date: '2024. 11. 18(수) · 11:00',
   },
   {
     profileImage: 'https://via.placeholder.com/40',
     name: '꼬미누나',
-    type: '지정', // 리터럴 타입 "지정"
-    details: '특이사항 없음',
-    date: '2024. 11. 18(수) · 11:00',
-  },
-  {
-    profileImage: 'https://via.placeholder.com/40',
-    name: '꼬미누나',
-    type: '지정', // 리터럴 타입 "지정"
+    type: '지정',
     details: '특이사항 없음',
     date: '2024. 11. 18(수) · 11:00',
   },
 ];
 
 export default function SheetList(): JSX.Element {
+  const [filterType, setFilterType] = useState<'전체' | '지정'>('전체');
+
+  const filteredData =
+    filterType === '전체' ? sheetData : sheetData.filter((data) => data.type === '지정');
+
   return (
     <div css={styles.wrapper}>
       <header css={styles.headerContainer}>견적</header>
       <div css={styles.tabContainer}>
-        <button css={[styles.tab, styles.activeTab]}>전체 견적서</button>
-        <button css={styles.tab}>지정 견적서</button>
+        <button
+          css={[styles.tab, filterType === '전체' && styles.activeTab]}
+          onClick={() => setFilterType('전체')}
+        >
+          전체 견적서
+        </button>
+        <button
+          css={[styles.tab, filterType === '지정' && styles.activeTab]}
+          onClick={() => setFilterType('지정')}
+        >
+          지정 견적서
+        </button>
       </div>
       <div css={styles.listContainer}>
-        {sheetData.map((data, index) => (
+        {filteredData.map((data, index) => (
           <SheetCard key={index} {...data} />
         ))}
       </div>
@@ -73,6 +90,12 @@ export default function SheetList(): JSX.Element {
 }
 
 function SheetCard({ profileImage, name, type, details, date }: SheetCardProps): JSX.Element {
+  const router = useRouter();
+
+  const handleDetailClick = () => {
+    router.push(`/details?name=${encodeURIComponent(name)}`); //임시 경로입니다
+  };
+
   return (
     <div css={styles.card}>
       {/* contentContainer */}
@@ -95,7 +118,9 @@ function SheetCard({ profileImage, name, type, details, date }: SheetCardProps):
 
       {/* detailContainer */}
       <div css={styles.detailContainer}>
-        <button css={styles.detailButton}>자세히 보기 &gt;</button>
+        <button css={styles.detailButton} onClick={handleDetailClick}>
+          자세히 보기 &gt;
+        </button>
       </div>
     </div>
   );

--- a/packages/services/tsconfig.json
+++ b/packages/services/tsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": ".",
     "paths": {
       "~/*": ["src/*"]
-    }
+    },
+    "jsxImportSource": "@emotion/react"
   },
   "include": ["src", "src/onboarding"],
   "exclude": ["node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5492,10 +5492,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 8.15.0
       '@typescript-eslint/type-utils': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
       '@typescript-eslint/utils': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
@@ -8418,7 +8418,7 @@ snapshots:
 
   typescript-eslint@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
       '@typescript-eslint/parser': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
       '@typescript-eslint/utils': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
       eslint: 9.15.0(jiti@1.21.6)


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #42 

<br/>

## 📝 관련 문서 레퍼런스

```
- [Notion] : https://www.notion.so/981021/2d77e81bf81f413690b30c8a1918138d?pvs=4#40fb97e515494364a1e20e761b1d3982
```

<br/>

## 💻 주요 변경 사항은 무엇인가요?

```
- 미용사가 조회하는 견적서 리스트 UI를 구현하였습니다.
```

<br/>

## 📚 추가된 라이브러리

```
- [추가] : NO
```

<br/>

## 📱 결과 화면 (선택)
<img src="https://github.com/user-attachments/assets/75f5913f-c859-4cd2-b484-729e7ff6ceed" width="200px" />
<img src="https://github.com/user-attachments/assets/7e65ce57-368e-4d10-9535-964d9aabe02a" width="200px" />

<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

```
- 자세히보기 버튼을 눌렀을 때에는 임시 루트로 라우팅 되도록 설정해두었습니다.
- 공통 컴포넌트로 푸터를 구현한 후 import 하기 위해 푸터 부분은 주석 처리 해두었습니다.
```
