### PR TITLE
[Task/package] emotion 세팅

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@daengle/design-system": "workspace:*",
+    "@emotion/react": "^11.13.5",
     "next": "14.2.10",
     "react": "^18",
     "react-dom": "^18"

--- a/apps/daengle/package.json
+++ b/apps/daengle/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@daengle/design-system": "workspace:*",
+    "@emotion/react": "^11.13.5",
     "next": "14.2.10",
     "react": "^18",
     "react-dom": "^18"

--- a/apps/daengle/src/pages/index.styles.ts
+++ b/apps/daengle/src/pages/index.styles.ts
@@ -1,0 +1,8 @@
+// Sample code
+import { css } from '@emotion/react';
+
+export const wrapper = css`
+  width: 100%;
+  max-width: 768px;
+  border: 1px solid #ccc;
+`;

--- a/apps/daengle/src/pages/index.tsx
+++ b/apps/daengle/src/pages/index.tsx
@@ -1,3 +1,5 @@
+import { wrapper } from './index.styles';
+
 export default function Home() {
-  return <div>Daengle</div>;
+  return <div css={wrapper}>Daengle</div>;
 }

--- a/apps/groomer/package.json
+++ b/apps/groomer/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@daengle/design-system": "workspace:*",
+    "@emotion/react": "^11.13.5",
     "next": "14.2.10",
     "react": "^18",
     "react-dom": "^18"

--- a/apps/vet/package.json
+++ b/apps/vet/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@daengle/design-system": "workspace:*",
+    "@emotion/react": "^11.13.5",
     "next": "14.2.10",
     "react": "^18",
     "react-dom": "^18"

--- a/packages/core/typescript-config/base.json
+++ b/packages/core/typescript-config/base.json
@@ -12,6 +12,8 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "ES2022"
+    "target": "ES2022",
+    "jsx": "react-jsx",
+    "jsxImportSource": "@emotion/react"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@daengle/design-system':
         specifier: workspace:*
         version: link:../../packages/core/design-system
+      '@emotion/react':
+        specifier: ^11.13.5
+        version: 11.13.5(@types/react@18.3.1)(react@18.3.1)
       next:
         specifier: 14.2.10
         version: 14.2.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.81.0)
@@ -106,6 +109,9 @@ importers:
       '@daengle/design-system':
         specifier: workspace:*
         version: link:../../packages/core/design-system
+      '@emotion/react':
+        specifier: ^11.13.5
+        version: 11.13.5(@types/react@18.3.12)(react@18.3.1)
       next:
         specifier: 14.2.10
         version: 14.2.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.81.0)
@@ -152,6 +158,9 @@ importers:
       '@daengle/design-system':
         specifier: workspace:*
         version: link:../../packages/core/design-system
+      '@emotion/react':
+        specifier: ^11.13.5
+        version: 11.13.5(@types/react@18.3.1)(react@18.3.1)
       next:
         specifier: 14.2.10
         version: 14.2.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.81.0)
@@ -277,6 +286,9 @@ importers:
       '@daengle/design-system':
         specifier: workspace:*
         version: link:../../packages/core/design-system
+      '@emotion/react':
+        specifier: ^11.13.5
+        version: 11.13.5(@types/react@18.3.1)(react@18.3.1)
       next:
         specifier: 14.2.10
         version: 14.2.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.81.0)
@@ -4583,6 +4595,38 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/react@11.13.5(@types/react@18.3.1)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.13.5
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.1.0(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      hoist-non-react-statics: 3.3.2
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/react@11.13.5(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.13.5
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.1.0(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      hoist-non-react-statics: 3.3.2
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #54 

<br/>

## 📝 관련 문서 레퍼런스

```
- [Slack] : [Slack](https://lgsw1.slack.com/archives/C0828AD3Z5F/p1732388916760619)
- [Notion] : X
```

<br/>

## 💻 주요 변경 사항은 무엇인가요?

```
- 프로젝트 파일마다 emotion을 설치하고 공통적인 tsconfig.json에 설정을 추가했습니다.

<br/>

## 📚 추가된 라이브러리

```
- [추가] : YES
- emotion
```

<br/>

## 📱 결과 화면 (선택)

<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

```
- 원래 컴포넌트를 대부분 package/design-system 내부에서 관리할 생각이었는데, 그러기에는 디자인이 먼저 완성되어야 할 것 같아서 우선적으로 각 프로젝트마다 emotion을 설치했습니다.
- daengle에 emotion 사용에 대한 샘플 코드 추가했으니 확인해 주세요!
```
