### PR TITLE
[Feature/daengle] 주소 등록 api 연동

### DIFF
--- a/apps/daengle/package.json
+++ b/apps/daengle/package.json
@@ -14,7 +14,8 @@
     "@emotion/react": "^11.13.5",
     "next": "14.2.10",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@daengle/eslint-config": "workspace:*",

--- a/apps/daengle/src/constants/routes.ts
+++ b/apps/daengle/src/constants/routes.ts
@@ -1,0 +1,48 @@
+export const ROUTES = {
+  LOGIN: '/login',
+  ONBOARDING: '/onboarding',
+  ONBOARDING_USER_INFO: '/onboarding/user-info',
+  ONBOARDING_SEARCH_ADDRESS: '/onboarding/search-address',
+  ONBOARDING_PET_INFO: '/onboarding/pet-info',
+
+  HOME: '/',
+  SEARCH: '/search',
+  SEARCH_RESULT: (keyword: string) => `/search?keyword=${keyword}`,
+
+  // Estimates
+  ESTIMATE_LIST: (type: string) => `/estimates/${type}`,
+  ESTIMATE_DETAIL: (estimateId: number) => `/estimates/${estimateId}`,
+
+  // Groomers
+  GROOMER_DETAIL: (groomerId: number) => `/groomers/${groomerId}`,
+  GROOMER_REVIEW: (groomerId: number) => `/groomers/${groomerId}/reviews`,
+  GROOMER_ESTIMATE_FORM: '/groomers/estimate-form',
+  GROOMER_REVIEW_FORM: '/groomers/review-form',
+  GROOMER_REVIEW_FORM_EDIT: '/groomers/review-form/edit',
+
+  // Vets
+  VET_DETAIL: (vetId: number) => `/vets/${vetId}`,
+  VET_REVIEW: (vetId: number) => `/vets/${vetId}/reviews`,
+  VET_ESTIMATE_FORM: '/vets/estimate-form',
+  VET_REVIEW_FORM: '/vets/review-form',
+  VET_REVIEW_FORM_EDIT: '/vets/review-form/edit',
+
+  RESERVATION_PAYMENT: '/reservations/payment',
+  RESERVATION_PAYMENT_COMPLETE: '/reservations/payment/complete',
+  RESERVATION_PAYMENT_FAILURE: '/reservations/payment/failure',
+  RESERVATIONS: '/reservations',
+  PAYMENTS: '/payments',
+
+  // Messages
+  MESSAGES: '/messages',
+  MESSAGES_DETAIL: (messageId: number) => `/messages/${messageId}`,
+
+  // Mypage
+  MYPAGE: '/mypage',
+  MYPAGE_USER_INFO: '/mypage/user-profile',
+  MYPAGE_USER_INFO_EDIT: '/mypage/user-profile/edit',
+  MAYPAGE_PET_PROFILE: '/mypage/pet-profile',
+  MAYPAGE_PET_PROFILE_EDIT: '/mypage/pet-profile/edit',
+  MYPAGE_REVIEWS: '/mypage/reviews',
+  MYPAGE_FAVORITES: '/mypage/favorites',
+};

--- a/apps/daengle/src/libs/libs.d.ts
+++ b/apps/daengle/src/libs/libs.d.ts
@@ -1,0 +1,1 @@
+export * from './postcode/index.d.ts';

--- a/apps/daengle/src/libs/postcode/index.d.ts
+++ b/apps/daengle/src/libs/postcode/index.d.ts
@@ -1,0 +1,124 @@
+declare global {
+  interface Window {
+    daum: {
+      postcode: {
+        load: (fn: () => void) => void;
+        version: string;
+        _validParam_: boolean;
+      };
+      Postcode: PostcodeConstructor;
+    };
+  }
+}
+
+export interface Address {
+  zonecode: string;
+  address: string;
+  addressEnglish: string;
+  addressType: 'R' | 'J';
+  userSelectedType: 'R' | 'J';
+  noSelected: 'Y' | 'N';
+  userLanguageType: 'K' | 'E';
+  roadAddress: string;
+  roadAddressEnglish: string;
+  jibunAddress: string;
+  jibunAddressEnglish: string;
+  autoRoadAddress: string;
+  autoRoadAddressEnglish: string;
+  autoJibunAddress: string;
+  autoJibunAddressEnglish: string;
+  buildingCode: string;
+  buildingName: string;
+  apartment: 'Y' | 'N';
+  sido: string;
+  sidoEnglish: string;
+  sigungu: string;
+  sigunguEnglish: string;
+  sigunguCode: string;
+  roadnameCode: string;
+  bcode: string;
+  roadname: string;
+  roadnameEnglish: string;
+  bname: string;
+  bnameEnglish: string;
+  bname1: string;
+  bname1English: string;
+  bname2: string;
+  bname2English: string;
+  hname: string;
+  query: string;
+}
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export type State = 'FORCE_CLOSE' | 'COMPLETE_CLOSE';
+
+export interface Search {
+  q: string;
+  count: number;
+}
+
+export interface Theme {
+  bgColor?: string;
+  searchBgColor?: string;
+  contentBgColor?: string;
+  pageBgColor?: string;
+  textColor?: string;
+  queryTextColor?: string;
+  postcodeTextColor?: string;
+  emphTextColor?: string;
+  outlineColor?: string;
+}
+
+export interface PostcodeOptions {
+  oncomplete?: (address: Address) => void;
+  onresize?: (size: Size) => void;
+  onclose?: (state: State) => void;
+  onsearch?: (search: Search) => void;
+  width?: string | number;
+  height?: string | number;
+  animation?: boolean;
+  focusInput?: boolean;
+  focusContent?: boolean;
+  autoMapping?: boolean;
+  autoMappingRoad?: boolean;
+  autoMappingJibun?: boolean;
+  shorthand?: boolean;
+  pleaseReadGuide?: number;
+  pleaseReadGuideTimer?: number;
+  maxSuggestItems?: number;
+  showMoreHName?: boolean;
+  hideMapBtn?: boolean;
+  hideEngBtn?: boolean;
+  alwaysShowEngAddr?: boolean;
+  submitMode?: boolean;
+  useBannerLink?: boolean;
+  theme?: Theme;
+  useSuggest?: boolean;
+}
+
+export interface OpenOptions {
+  q?: string;
+  left?: number | string;
+  top?: number | string;
+  popupTitle?: string;
+  popupKey?: string;
+  autoClose?: boolean;
+}
+
+export interface EmbedOptions {
+  q?: string;
+  autoClose?: boolean;
+}
+
+export interface PostcodeConstructor {
+  new (postcodeOptions: PostcodeOptions): Postcode;
+}
+
+export interface Postcode {
+  open(openOptions?: OpenOptions): void;
+  embed(element: HTMLElement, embedOptions?: EmbedOptions): void;
+}

--- a/apps/daengle/src/libs/postcode/index.tsx
+++ b/apps/daengle/src/libs/postcode/index.tsx
@@ -1,0 +1,116 @@
+import { useState, useRef, useEffect, CSSProperties, ReactNode } from 'react';
+import { PostcodeConstructor, PostcodeOptions, Address as AddressType } from './index.d';
+
+export const POSTCODE_SCRIPT_URL =
+  'https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
+
+export type Address = AddressType;
+
+export interface DaumPostcodeProps
+  extends Omit<
+    PostcodeOptions,
+    'oncomplete' | 'onresize' | 'onclose' | 'onsearch' | 'width' | 'height'
+  > {
+  onComplete?: PostcodeOptions['oncomplete'];
+  onResize?: PostcodeOptions['onresize'];
+  onClose?: PostcodeOptions['onclose'];
+  onSearch?: PostcodeOptions['onsearch'];
+  className?: string;
+  style?: CSSProperties;
+  defaultQuery?: string;
+  errorMessage?: string | ReactNode;
+  scriptUrl?: string;
+  autoClose?: boolean;
+}
+
+export const loadPostcode = (() => {
+  const scriptId = 'daum_postcode_script';
+  let promise: Promise<PostcodeConstructor> | null = null;
+
+  return (url: string = POSTCODE_SCRIPT_URL): Promise<PostcodeConstructor> => {
+    if (promise) return promise;
+
+    promise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = url;
+      script.onload = () => {
+        if (window?.daum?.Postcode) {
+          return resolve(window.daum.Postcode);
+        }
+        reject(new Error('주소 검색 서비스를 불러오는 데 실패했어요. 다시 시도해 주세요.'));
+      };
+      script.onerror = (error) => reject(error);
+      script.id = scriptId;
+
+      document.body.appendChild(script);
+    });
+
+    return promise;
+  };
+})();
+
+const defaultErrorMessage = (
+  <p>현재 Daum 우편번호 서비스를 이용할 수 없습니다. 잠시 후 다시 시도해 주세요.</p>
+);
+
+const defaultStyle = {
+  width: '100%',
+  height: '100%',
+};
+
+export default function DaumPostcode({
+  scriptUrl = POSTCODE_SCRIPT_URL,
+  errorMessage = defaultErrorMessage,
+  autoClose = true,
+  className,
+  style,
+  defaultQuery,
+  onComplete,
+  onResize,
+  onClose,
+  onSearch,
+  ...options
+}: DaumPostcodeProps) {
+  const wrap = useRef<HTMLDivElement | null>(null);
+  const [hasError, setHasError] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!scriptUrl) return;
+
+    let mounted = true;
+
+    loadPostcode(scriptUrl)
+      .then((Postcode) => {
+        if (!mounted || !wrap.current) return;
+
+        const postcode = new Postcode({
+          ...options,
+          oncomplete: (address) => {
+            if (onComplete) onComplete(address);
+            if (autoClose && wrap.current) wrap.current.innerHTML = '';
+          },
+          onsearch: onSearch,
+          onresize: onResize,
+          onclose: onClose,
+          width: '100%',
+          height: '100%',
+        });
+
+        postcode.embed(wrap.current, { q: defaultQuery, autoClose });
+      })
+      .catch((error) => {
+        console.error(error);
+        setHasError(true);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [scriptUrl, autoClose, defaultQuery, onComplete, onResize, onClose, onSearch, options]);
+
+  return (
+    <div ref={wrap} className={className} style={{ ...defaultStyle, ...style }}>
+      {hasError && errorMessage}
+    </div>
+  );
+}

--- a/apps/daengle/src/pages/onboarding/search-address/index.styles.ts
+++ b/apps/daengle/src/pages/onboarding/search-address/index.styles.ts
@@ -1,0 +1,6 @@
+import { css } from '@emotion/react';
+
+export const wrapper = css`
+  width: 100%;
+  height: 100%;
+`;

--- a/apps/daengle/src/pages/onboarding/search-address/index.tsx
+++ b/apps/daengle/src/pages/onboarding/search-address/index.tsx
@@ -1,0 +1,23 @@
+import { useRouter } from 'next/router';
+import { AppBar } from '@daengle/design-system';
+import { ROUTES } from '~/constants/routes';
+import DaumPostcode, { Address } from '~/libs/postcode';
+import { useSearchAddressStore } from '~/store/onboarding/address';
+import { wrapper } from './index.styles';
+
+export default function SearchAddress() {
+  const router = useRouter();
+  const { setAddress } = useSearchAddressStore();
+
+  const handleSearchAddressComplete = (data: Address) => {
+    setAddress(data);
+    router.replace(ROUTES.ONBOARDING_USER_INFO);
+  };
+
+  return (
+    <section css={wrapper}>
+      <AppBar onBackClick={router.back} />
+      <DaumPostcode onComplete={handleSearchAddressComplete} />
+    </section>
+  );
+}

--- a/apps/daengle/src/pages/onboarding/user-info/index.tsx
+++ b/apps/daengle/src/pages/onboarding/user-info/index.tsx
@@ -1,19 +1,22 @@
-import {
-  AppBar,
-  CapsuleButton,
-  CTAButton,
-  Input,
-  RoundButton,
-  Text,
-  theme,
-} from '@daengle/design-system';
+import { useMemo } from 'react';
+import { useRouter } from 'next/router';
+import { AppBar, CapsuleButton, CTAButton, Input, RoundButton, Text } from '@daengle/design-system';
+import { ROUTES } from '~/constants/routes';
+import { useSearchAddressStore } from '~/store/onboarding/address';
 import { location, locationButton, section, wrapper } from './index.styles';
 
 export default function UserInfo() {
+  const router = useRouter();
+  const { address } = useSearchAddressStore();
+
+  const jibunAddress = useMemo(
+    () => `${address?.sido} ${address?.sigungu} ${address?.bname}`,
+    [address]
+  );
+
   return (
     <>
       <AppBar />
-
       <div css={wrapper}>
         <Text typo="semibold01" color="black">
           회원 정보를 입력해 주세요
@@ -30,11 +33,21 @@ export default function UserInfo() {
             <Text typo="medium01" color="black">
               위치 설정
             </Text>
-            <RoundButton variant="ghost" fullWidth>
+            <RoundButton
+              variant="ghost"
+              fullWidth
+              onClick={() => router.push(ROUTES.ONBOARDING_SEARCH_ADDRESS)}
+            >
               <div css={locationButton}>
-                <Text typo="regular02" color="gray200">
-                  위치(필수)
-                </Text>
+                {address ? (
+                  <Text typo="regular02" color="black">
+                    {jibunAddress}
+                  </Text>
+                ) : (
+                  <Text typo="regular02" color="gray200">
+                    위치(필수)
+                  </Text>
+                )}
               </div>
             </RoundButton>
           </div>

--- a/apps/daengle/src/store/onboarding/address.ts
+++ b/apps/daengle/src/store/onboarding/address.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+import type { Address } from '~/libs/postcode';
+
+interface SearchAddress {
+  address: Address | null;
+  setAddress: (address: Address) => void;
+}
+
+export const useSearchAddressStore = create<SearchAddress>((set) => {
+  return {
+    address: null,
+    setAddress: (address: Address) => set({ address }),
+  };
+});

--- a/apps/daengle/tsconfig.json
+++ b/apps/daengle/tsconfig.json
@@ -7,6 +7,13 @@
       "~/*": ["src/*"]
     }
   },
-  "include": ["next-env.d.ts", "next.config.mjs", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "next.config.mjs",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "./src/libs/libs.d.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/packages/core/design-system/src/components/button/cta-button/index.styles.ts
+++ b/packages/core/design-system/src/components/button/cta-button/index.styles.ts
@@ -6,6 +6,6 @@ export const wrapper = css`
   bottom: 18px;
   z-index: ${theme.zIndex.ctaButton};
   margin: 0 auto;
-  width: 100%;
+  width: calc(100% - 36px);
   max-width: calc(${theme.size.maxWidth} - 36px);
 `;

--- a/packages/services/src/onboarding/api/index.ts
+++ b/packages/services/src/onboarding/api/index.ts
@@ -1,7 +1,0 @@
-import axios from 'axios';
-
-// Example code
-export const getUsersProfile = async () => {
-  const response = await axios.get('/users/profile');
-  return response.data;
-};

--- a/packages/services/src/onboarding/index.ts
+++ b/packages/services/src/onboarding/index.ts
@@ -1,1 +1,0 @@
-export * from './api';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
+      zustand:
+        specifier: ^5.0.1
+        version: 5.0.1(@types/react@18.3.12)(react@18.3.1)
     devDependencies:
       '@daengle/eslint-config':
         specifier: workspace:*
@@ -4319,6 +4322,24 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
+  zustand@5.0.1:
+    resolution: {integrity: sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@adobe/css-tools@4.4.1': {}
@@ -5556,10 +5577,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4)
       '@typescript-eslint/scope-manager': 8.15.0
       '@typescript-eslint/type-utils': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
       '@typescript-eslint/utils': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
@@ -8489,7 +8510,7 @@ snapshots:
 
   typescript-eslint@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
       '@typescript-eslint/parser': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
       '@typescript-eslint/utils': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.6.3)
       eslint: 9.15.0(jiti@1.21.6)
@@ -8679,3 +8700,8 @@ snapshots:
   yocto-queue@1.1.1: {}
 
   yoctocolors-cjs@2.1.2: {}
+
+  zustand@5.0.1(@types/react@18.3.12)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.12
+      react: 18.3.1


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #73 

<br/>

## 📝 관련 문서 레퍼런스

```
- [Slack] : X
- [Notion] : X
```

<br/>

## 💻 주요 변경 사항은 무엇인가요?

```
- 주소 등록 api를 연동했습니다.
- `/constants/routes.ts`를 생성하여 페이지 경로를 상수로 관리합니다 (확정은 아니라 나중에 수정할 수 있습니다!!)
```

<br/>

## 📚 추가된 라이브러리

```
- [추가] : NO
```

<br/>

## 📱 결과 화면 (선택)
![Nov-27-2024 15-56-51](https://github.com/user-attachments/assets/28273209-4e06-419f-8521-ab193242cf5c)


<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

```
- 
```
