### PR TITLE
[Design/daengle] 사용자 견적서 상세 조회 UI 구현

### DIFF
--- a/apps/daengle/next.config.mjs
+++ b/apps/daengle/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['@daengle/design-system'],
+  transpilePackages: ['@daengle/design-system', '@daengle/services'],
 };
 
 export default nextConfig;

--- a/apps/daengle/src/pages/estimate/index.styles.ts
+++ b/apps/daengle/src/pages/estimate/index.styles.ts
@@ -1,0 +1,25 @@
+import { css } from '@emotion/react';
+
+export const wrapper = css`
+  background-color: #f3f5f8;
+`;
+
+export const header = css`
+  display: flex;
+  align-items: center;
+  margin: 18px;
+`;
+
+export const section = css`
+  display: flex;
+  flex-direction: column;
+  margin: 18px;
+  gap: 11px;
+`;
+
+export const buttonGroup = css`
+  display: flex;
+  gap: 13px;
+  margin: 32px 18px 18px;
+  justify-content: center;
+`;

--- a/apps/daengle/src/pages/estimate/index.tsx
+++ b/apps/daengle/src/pages/estimate/index.tsx
@@ -1,0 +1,53 @@
+import { AppBar, RoundButton, Text } from '@daengle/design-system';
+import { wrapper, header, section, buttonGroup } from './index.styles';
+import { DesignerInfo, Receipt } from '@daengle/services';
+
+export default function Detail() {
+  const designerData = {
+    id: 1,
+    name: '미용사A',
+    shopName: '꼬꼬마 관리샵',
+    image: '/local-image.jpg',
+    daengleMeter: 30,
+    tags: ['대형견', '노견'],
+    address: '서울특별시 관악구',
+    reservedDate: '2024-11-25(월) 11:33',
+    desiredStyle: '대형견 - 전체 가위컷',
+    overallOpinion: '아이의 편안함을 위해 조심스럽게 진행하겠습니다. 추가 의견 없음.',
+  };
+
+  return (
+    <div css={wrapper}>
+      <AppBar isDefaultBackground={false} />
+      <header css={header}>
+        <Text typo="title1">견적 상세</Text>
+      </header>
+      <DesignerInfo profile={designerData} />
+      <section css={section}>
+        <Text typo="body1">소개</Text>
+        <Text typo="body10" tag="div">
+          모든 견종의 가위컷에 자신이 있으며, 특히, 푸들 테디베어컷, 비숑 귀툭튀컷, 포메 곰돌이컷 등
+          디자인컷 완성도에 자신이 있습니다.
+        </Text>
+      </section>
+      <Receipt receipt={designerData} />
+      <div css={buttonGroup}>
+        <RoundButton variant="primary" size="S" fullWidth>
+          <Text typo="body1" color="white">
+            채팅 문의
+          </Text>
+        </RoundButton>
+        <RoundButton
+          variant="primary"
+          size="S"
+          fullWidth
+          onClick={() => alert('예약금 결제를 진행합니다.')}
+        >
+          <Text typo="body1" color="white">
+            예약금 결제
+          </Text>
+        </RoundButton>
+      </div>
+    </div>
+  );
+}

--- a/apps/daengle/src/pages/estimate/index.tsx
+++ b/apps/daengle/src/pages/estimate/index.tsx
@@ -1,4 +1,4 @@
-import { AppBar, RoundButton, Text } from '@daengle/design-system';
+import { AppBar, Layout, RoundButton, Text } from '@daengle/design-system';
 import { wrapper, header, section, buttonGroup } from './index.styles';
 import { DesignerInfo, Receipt } from '@daengle/services';
 
@@ -17,37 +17,46 @@ export default function Detail() {
   };
 
   return (
-    <div css={wrapper}>
-      <AppBar isDefaultBackground={false} />
-      <header css={header}>
-        <Text typo="title1">견적 상세</Text>
-      </header>
-      <DesignerInfo profile={designerData} />
-      <section css={section}>
-        <Text typo="body1">소개</Text>
-        <Text typo="body10" tag="div">
-          모든 견종의 가위컷에 자신이 있으며, 특히, 푸들 테디베어컷, 비숑 귀툭튀컷, 포메 곰돌이컷 등
-          디자인컷 완성도에 자신이 있습니다.
-        </Text>
-      </section>
-      <Receipt receipt={designerData} />
-      <div css={buttonGroup}>
-        <RoundButton variant="primary" size="S" fullWidth>
-          <Text typo="body1" color="white">
-            채팅 문의
+    <Layout>
+      <div css={wrapper}>
+        <AppBar isDefaultBackground={false} />
+        <div css={header}>
+          <Text typo="title1">견적 상세</Text>
+        </div>
+        <DesignerInfo profile={designerData} />
+        <section css={section}>
+          <Text typo="body1">소개</Text>
+          <Text typo="body10" tag="div">
+            모든 견종의 가위컷에 자신이 있으며, 특히, 푸들 테디베어컷, 비숑 귀툭튀컷, 포메 곰돌이컷
+            등 디자인컷 완성도에 자신이 있습니다.
           </Text>
-        </RoundButton>
-        <RoundButton
-          variant="primary"
-          size="S"
-          fullWidth
-          onClick={() => alert('예약금 결제를 진행합니다.')}
-        >
-          <Text typo="body1" color="white">
-            예약금 결제
-          </Text>
-        </RoundButton>
+        </section>
+        <Receipt
+          items={[
+            { title: '지역', receipt: designerData.address },
+            { title: '일정', receipt: designerData.reservedDate },
+            { title: '서비스', receipt: designerData.desiredStyle },
+            { title: '추가 소견', receipt: designerData.overallOpinion, typo: 'body4' },
+          ]}
+        />
+        <div css={buttonGroup}>
+          <RoundButton variant="primary" size="S" fullWidth>
+            <Text typo="body1" color="white">
+              채팅 문의
+            </Text>
+          </RoundButton>
+          <RoundButton
+            variant="primary"
+            size="S"
+            fullWidth
+            onClick={() => alert('예약금 결제를 진행합니다.')}
+          >
+            <Text typo="body1" color="white">
+              예약금 결제
+            </Text>
+          </RoundButton>
+        </div>
       </div>
-    </div>
+    </Layout>
   );
 }

--- a/packages/core/design-system/src/components/app-bar/index.styles.ts
+++ b/packages/core/design-system/src/components/app-bar/index.styles.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { theme } from '../../foundation';
 
-export const wrapper = css`
+export const wrapper = (isDefaultBackground: boolean) => css`
   position: fixed;
   top: 0;
   margin: 0 auto;
@@ -9,7 +9,7 @@ export const wrapper = css`
   width: 100%;
   height: 52px;
   max-width: ${theme.size.maxWidth};
-  background: ${theme.colors.white};
+  background: ${isDefaultBackground ? theme.colors.white : '#f3f5f8'};
 `;
 
 export const contents = css`

--- a/packages/core/design-system/src/components/app-bar/index.tsx
+++ b/packages/core/design-system/src/components/app-bar/index.tsx
@@ -8,11 +8,12 @@ interface Props {
   prefix?: ReactNode;
   title?: string;
   suffix?: ReactNode;
+  isDefaultBackground?: boolean;
 }
 
-export function AppBar({ onBackClick, prefix, title, suffix }: Props) {
+export function AppBar({ onBackClick, prefix, title, suffix, isDefaultBackground = true }: Props) {
   return (
-    <header css={wrapper}>
+    <header css={wrapper(isDefaultBackground)}>
       <div css={contents}>
         {prefix ? prefix : <AppBarBack width="8px" cursor="pointer" onClick={onBackClick} />}
         {title && (

--- a/packages/services/src/estimate/components/estimate/daengle/partners-profile/index.styles.ts
+++ b/packages/services/src/estimate/components/estimate/daengle/partners-profile/index.styles.ts
@@ -1,0 +1,33 @@
+import { css } from '@emotion/react';
+import { theme } from '@daengle/design-system';
+
+export const wrapper = css`
+  display: flex;
+  gap: 15px;
+  margin: 6px 18px;
+`;
+
+export const profileImage = css`
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+export const details = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 6px;
+`;
+
+export const tags = css`
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+`;
+
+export const tag = css`
+  background-color: transparent;
+  padding: 5px 17px;
+  border-radius: 14px;
+  border: 0.5px solid ${theme.colors.blue200};
+`;

--- a/packages/services/src/estimate/components/estimate/daengle/partners-profile/index.tsx
+++ b/packages/services/src/estimate/components/estimate/daengle/partners-profile/index.tsx
@@ -1,0 +1,45 @@
+import { Text, TextButton } from '@daengle/design-system';
+import { ButtonTextButtonArrow } from '@daengle/design-system/icons';
+import { wrapper, profileImage, details, tags, tag } from './index.styles';
+
+interface Props {
+  profile: {
+    id: number;
+    name: string;
+    shopName: string;
+    image: string;
+    daengleMeter: number;
+    tags: string[];
+  };
+}
+
+export const DesignerInfo = ({ profile }: Props) => {
+  return (
+    <div css={wrapper}>
+      <img
+        src={profile.image}
+        width={112}
+        height={112}
+        alt={`${profile.name} 프로필`}
+        css={profileImage}
+      />
+      <div css={details}>
+        <Text typo="title2">{profile.name}</Text>
+        <TextButton icons={{ suffix: <ButtonTextButtonArrow width={'6px'} /> }}>
+          <Text color="gray500" typo="body8">
+            {profile.shopName}
+          </Text>
+        </TextButton>
+        <div css={tags}>
+          {profile.tags.map((hashtag, index) => (
+            <Text color="blue200" typo="body12" key={`${profile.id}-${index}`} css={tag}>
+              #{hashtag}
+            </Text>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DesignerInfo;

--- a/packages/services/src/estimate/components/estimate/daengle/receipt-content/index.styles.ts
+++ b/packages/services/src/estimate/components/estimate/daengle/receipt-content/index.styles.ts
@@ -1,0 +1,10 @@
+import { css } from '@emotion/react';
+
+export const content = css`
+  display: flex;
+  flex-direction: column;
+  padding: 18px;
+  background-color: #ffffff;
+  gap: 8px;
+  margin: -2px 14px;
+`;

--- a/packages/services/src/estimate/components/estimate/daengle/receipt-content/index.tsx
+++ b/packages/services/src/estimate/components/estimate/daengle/receipt-content/index.tsx
@@ -1,0 +1,21 @@
+import { Text } from '@daengle/design-system';
+import { content } from './index.styles';
+
+interface Props {
+  title: string;
+  receipt: string;
+  typo?: 'subtitle3' | 'body4';
+}
+
+const Content = ({ title, receipt, typo = 'subtitle3' }: Props) => {
+  return (
+    <section css={content}>
+      <Text typo="body4" color="gray400">
+        {title}
+      </Text>
+      <Text typo={typo}>{receipt}</Text>
+    </section>
+  );
+};
+
+export default Content;

--- a/packages/services/src/estimate/components/estimate/daengle/receipt-estimate/index.styles.ts
+++ b/packages/services/src/estimate/components/estimate/daengle/receipt-estimate/index.styles.ts
@@ -1,0 +1,106 @@
+import { css } from '@emotion/react';
+
+export const wrapper = css`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+`;
+
+export const zigzagContainer = css`
+  margin: 0 14px;
+  overflow: hidden;
+`;
+
+export const zigzag = css`
+  width: calc(100% + 28px);
+  height: 16px;
+  background-color: white;
+  clip-path: polygon(
+    0% 100%,
+    2.8571% 100%,
+    2.8571% 0%,
+    7.1429% 100%,
+    10.7143% 0%,
+    14.2857% 100%,
+    17.8571% 0%,
+    21.4286% 100%,
+    25% 0%,
+    28.5714% 100%,
+    32.1429% 0%,
+    35.7143% 100%,
+    39.2857% 0%,
+    42.8571% 100%,
+    46.4286% 0%,
+    50% 100%,
+    53.5714% 0%,
+    57.1429% 100%,
+    60.7143% 0%,
+    64.2857% 100%,
+    67.8571% 0%,
+    71.4286% 100%,
+    75% 0%,
+    78.5714% 100%,
+    82.1429% 0%,
+    85.7143% 100%,
+    89.2857% 0%,
+    92.8571% 100%,
+    97.1429% 0%,
+    97.1429% 100%,
+    100% 100%
+  );
+  transform: translateX(-14px);
+  box-sizing: border-box;
+`;
+
+export const zigzagUpsideDown = css`
+  width: calc(100% + 28px);
+  height: 16px;
+  background-color: white;
+  clip-path: polygon(
+    0% 0%,
+    2.8571% 0%,
+    2.8571% 100%,
+    7.1429% 0%,
+    10.7143% 100%,
+    14.2857% 0%,
+    17.8571% 100%,
+    21.4286% 0%,
+    25% 100%,
+    28.5714% 0%,
+    32.1429% 100%,
+    35.7143% 0%,
+    39.2857% 100%,
+    42.8571% 0%,
+    46.4286% 100%,
+    50% 0%,
+    53.5714% 100%,
+    57.1429% 0%,
+    60.7143% 100%,
+    64.2857% 0%,
+    67.8571% 100%,
+    71.4286% 0%,
+    75% 100%,
+    78.5714% 0%,
+    82.1429% 100%,
+    85.7143% 0%,
+    89.2857% 100%,
+    92.8571% 0%,
+    97.1429% 100%,
+    97.1429% 0%,
+    100% 0%
+  );
+  transform: translateX(-14px);
+  box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.05);
+  box-sizing: border-box;
+`;
+
+export const content = css`
+  display: flex;
+  flex-direction: column;
+  padding: 18px;
+  background-color: #ffffff;
+  gap: 8px;
+  margin: -2px 14px;
+`;

--- a/packages/services/src/estimate/components/estimate/daengle/receipt-estimate/index.styles.ts
+++ b/packages/services/src/estimate/components/estimate/daengle/receipt-estimate/index.styles.ts
@@ -95,12 +95,3 @@ export const zigzagUpsideDown = css`
   box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.05);
   box-sizing: border-box;
 `;
-
-export const content = css`
-  display: flex;
-  flex-direction: column;
-  padding: 18px;
-  background-color: #ffffff;
-  gap: 8px;
-  margin: -2px 14px;
-`;

--- a/packages/services/src/estimate/components/estimate/daengle/receipt-estimate/index.tsx
+++ b/packages/services/src/estimate/components/estimate/daengle/receipt-estimate/index.tsx
@@ -1,51 +1,23 @@
-import { Text } from '@daengle/design-system';
-import { wrapper, zigzagContainer, zigzag, content, zigzagUpsideDown } from './index.styles';
+import { wrapper, zigzagContainer, zigzag, zigzagUpsideDown } from './index.styles';
+import Content from '../receipt-content';
 
 interface Props {
-  receipt: {
-    id: number;
-    daengleMeter: number;
-    tags: string[];
-    address: string;
-    reservedDate: string;
-    desiredStyle: string;
-    overallOpinion: string;
-  };
+  items: {
+    title: string;
+    receipt: string;
+    typo?: 'subtitle3' | 'body4';
+  }[];
 }
 
-const Receipt = ({ receipt }: Props) => {
+const Receipt = ({ items }: Props) => {
   return (
     <div css={wrapper}>
       <div css={zigzagContainer}>
         <div css={zigzag}></div>
       </div>
-      <section css={content}>
-        <Text typo="body4" color="gray400">
-          지역
-        </Text>
-        <Text typo="subtitle3">{receipt.address}</Text>
-      </section>
-
-      <section css={content}>
-        <Text typo="body4" color="gray400">
-          일정
-        </Text>
-        <Text typo="subtitle3">{receipt.reservedDate}</Text>
-      </section>
-
-      <section css={content}>
-        <Text typo="body4" color="gray400">
-          서비스
-        </Text>
-        <Text typo="subtitle3">{receipt.desiredStyle}</Text>
-      </section>
-
-      <section css={content}>
-        <Text typo="body4" color="gray400">
-          추가 소견
-        </Text>
-        <Text typo="body4">{receipt.overallOpinion}</Text>
-      </section>
+      {items.map((item, index) => (
+        <Content key={index} {...item} />
+      ))}
       <div css={zigzagContainer}>
         <div css={zigzagUpsideDown}></div>
       </div>

--- a/packages/services/src/estimate/components/estimate/daengle/receipt-estimate/index.tsx
+++ b/packages/services/src/estimate/components/estimate/daengle/receipt-estimate/index.tsx
@@ -1,0 +1,56 @@
+import { Text } from '@daengle/design-system';
+import { wrapper, zigzagContainer, zigzag, content, zigzagUpsideDown } from './index.styles';
+
+interface Props {
+  receipt: {
+    id: number;
+    daengleMeter: number;
+    tags: string[];
+    address: string;
+    reservedDate: string;
+    desiredStyle: string;
+    overallOpinion: string;
+  };
+}
+
+const Receipt = ({ receipt }: Props) => {
+  return (
+    <div css={wrapper}>
+      <div css={zigzagContainer}>
+        <div css={zigzag}></div>
+      </div>
+      <section css={content}>
+        <Text typo="body4" color="gray400">
+          지역
+        </Text>
+        <Text typo="subtitle3">{receipt.address}</Text>
+      </section>
+
+      <section css={content}>
+        <Text typo="body4" color="gray400">
+          일정
+        </Text>
+        <Text typo="subtitle3">{receipt.reservedDate}</Text>
+      </section>
+
+      <section css={content}>
+        <Text typo="body4" color="gray400">
+          서비스
+        </Text>
+        <Text typo="subtitle3">{receipt.desiredStyle}</Text>
+      </section>
+
+      <section css={content}>
+        <Text typo="body4" color="gray400">
+          추가 소견
+        </Text>
+        <Text typo="body4">{receipt.overallOpinion}</Text>
+      </section>
+      <div css={zigzagContainer}>
+        <div css={zigzagUpsideDown}></div>
+      </div>
+    </div>
+  );
+};
+
+export default Receipt;

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,2 +1,3 @@
 export { default as DesignerInfo } from './estimate/components/estimate/daengle/partners-profile';
 export { default as Receipt } from './estimate/components/estimate/daengle/receipt-estimate';
+export { default as Content } from './estimate/components/estimate/daengle/receipt-content';

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,0 +1,2 @@
+export { default as DesignerInfo } from './estimate/components/estimate/daengle/partners-profile';
+export { default as Receipt } from './estimate/components/estimate/daengle/receipt-estimate';


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #94 

<br/>

## 📝 관련 문서 레퍼런스

```
- [Slack] : X
- [Notion] : https://www.notion.so/981021/2d77e81bf81f413690b30c8a1918138d?pvs=4#f80b33612e0c48278a16829158927de6
```

<br/>

## 💻 주요 변경 사항은 무엇인가요?

```
- 사용자가 확인하는 견적서 상세 조회 UI를 구현하였습니다.
```

<br/>

## 📚 추가된 라이브러리

```
- [추가] : NO
```

<br/>

## 📱 결과 화면 (선택)
<img src="https://github.com/user-attachments/assets/82b66087-57b5-4b0e-8b3d-1a4d3cfd20b0" width="200px" />
<img src="https://github.com/user-attachments/assets/54fa6805-510e-4676-8579-20642440addf" width="200px" />
<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

```
- 
```
