### PR TITLE
[Design/daengle] 예약금 결제 페이지 UI 구현

### DIFF
--- a/apps/daengle/src/pages/order/index.styles.ts
+++ b/apps/daengle/src/pages/order/index.styles.ts
@@ -1,0 +1,122 @@
+import { theme } from '@daengle/design-system';
+import { css } from '@emotion/react';
+
+export const wrapper = css`
+  padding: 18px 0 104px 0;
+`;
+
+export const section = css`
+  padding: 0 18px;
+`;
+
+export const title = css`
+  margin-bottom: 24px;
+`;
+
+export const subtitle = css`
+  margin: 6px 0;
+`;
+
+export const line = css`
+  width: 100%;
+  height: 8px;
+  background-color: ${theme.colors.gray100};
+  margin: 24px 0;
+`;
+
+export const reservationInfo = css`
+  border: 2px solid ${theme.colors.blue200};
+  border-radius: 21px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  margin: 14px 0;
+`;
+
+export const schedule = css`
+  display: flex;
+  margin-top: 12px;
+  justify-content: space-between;
+`;
+
+export const dateTime = css`
+  display: flex;
+  gap: 11px;
+`;
+
+export const reservationPrice = css`
+  padding: 0 18px;
+`;
+
+export const price = css`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const thinLine = css`
+  width: 100%;
+  height: 1px;
+  background-color: ${theme.colors.black};
+  margin: 14px 0;
+`;
+
+export const totalPrice = css`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const additionalInfoBox = css`
+  margin-top: 32px;
+`;
+
+export const additionalInfo = css`
+  width: 100%;
+  height: 34px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const additionalInfoButton = css`
+  width: 210px;
+  height: 34px;
+  background-color: ${theme.colors.gray100};
+  border-radius: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+`;
+
+export const arrow = css`
+  position: absolute;
+  right: 18px;
+`;
+
+export const grayLine = css`
+  width: 100%;
+  height: 1px;
+  background-color: ${theme.colors.gray200};
+`;
+
+export const visitorInfo = css`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+export const capsuleButton = css`
+  width: 41px;
+  height: 26px;
+`;
+
+export const inputTitle = css`
+  margin: 20px 0;
+`;
+
+export const input = css`
+  margin-bottom: 18px;
+`;

--- a/apps/daengle/src/pages/order/index.styles.ts
+++ b/apps/daengle/src/pages/order/index.styles.ts
@@ -94,12 +94,14 @@ export const additionalInfoButton = css`
 export const arrow = css`
   position: absolute;
   right: 18px;
+
+  stroke: ${theme.colors.gray300};
 `;
 
 export const grayLine = css`
   width: 100%;
   height: 1px;
-  background-color: ${theme.colors.gray200};
+  background-color: ${theme.colors.gray100};
 `;
 
 export const visitorInfo = css`
@@ -108,10 +110,12 @@ export const visitorInfo = css`
   gap: 6px;
 `;
 
-export const capsuleButton = css`
-  width: 41px;
-  height: 26px;
-`;
+export const hiddenBlock = ({ isOpen }: { isOpen: boolean }) => ({
+  maxHeight: isOpen ? '200px' : '0',
+  overflow: 'hidden',
+  transition: 'max-height 0.3s ease',
+  opacity: isOpen ? 1 : 0,
+});
 
 export const inputTitle = css`
   margin: 20px 0;

--- a/apps/daengle/src/pages/order/index.tsx
+++ b/apps/daengle/src/pages/order/index.tsx
@@ -18,12 +18,19 @@ import {
   arrow,
   grayLine,
   visitorInfo,
+  hiddenBlock,
   inputTitle,
   input,
 } from './index.styles';
-import { SelectUnfoldInactive } from '@daengle/design-system/icons';
+import { SelectUnfoldActive, SelectUnfoldInactive } from '@daengle/design-system/icons';
+import { useState } from 'react';
 
 export default function Order() {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const handleArrowToggle = () => {
+    setIsOpen(!isOpen);
+  };
   return (
     <Layout>
       <AppBar />
@@ -111,15 +118,21 @@ export default function Order() {
                 <Text typo="body5" color="gray600">
                   실제 방문자가 다르신가요?
                 </Text>
-                <SelectUnfoldInactive width={12} css={arrow} />
+                {isOpen ? (
+                  <SelectUnfoldActive width={12} css={arrow} onClick={handleArrowToggle} />
+                ) : (
+                  <SelectUnfoldInactive width={12} css={arrow} onClick={handleArrowToggle} />
+                )}
               </div>
               <div css={grayLine} />
             </div>
-            <Text tag="h3" typo="body4" color="black" css={inputTitle}>
-              실제 방문하실 분의 정보를 입력해주세요
-            </Text>
-            <Input label="방문자" placeholder="방문자 이름을 입력해주세요" css={input} />
-            <Input label="휴대폰번호" placeholder="휴대폰 번호를 입력해주세요" />
+            <div css={hiddenBlock({ isOpen })}>
+              <Text tag="h3" typo="body4" color="black" css={inputTitle}>
+                실제 방문하실 분의 정보를 입력해주세요
+              </Text>
+              <Input label="방문자" placeholder="방문자 이름을 입력해주세요" css={input} />
+              <Input label="휴대폰번호" placeholder="휴대폰 번호를 입력해주세요" />
+            </div>
           </section>
           <CTAButton>예약하기</CTAButton>
         </section>

--- a/apps/daengle/src/pages/order/index.tsx
+++ b/apps/daengle/src/pages/order/index.tsx
@@ -1,0 +1,129 @@
+import { AppBar, CapsuleButton, CTAButton, Input, Layout, Text } from '@daengle/design-system';
+import {
+  wrapper,
+  section,
+  title,
+  subtitle,
+  line,
+  reservationInfo,
+  schedule,
+  dateTime,
+  reservationPrice,
+  price,
+  thinLine,
+  totalPrice,
+  additionalInfoBox,
+  additionalInfo,
+  additionalInfoButton,
+  arrow,
+  grayLine,
+  visitorInfo,
+  inputTitle,
+  input,
+} from './index.styles';
+import { SelectUnfoldInactive } from '@daengle/design-system/icons';
+
+export default function Order() {
+  return (
+    <Layout>
+      <AppBar />
+      <div css={wrapper}>
+        <section css={section}>
+          <Text tag="h1" typo="title1" css={title}>
+            예약금 결제하기
+          </Text>
+          <Text tag="h2" typo="subtitle1">
+            예약 시 예약금이 결제됩니다.
+          </Text>
+          <Text tag="h2" typo="subtitle1" color="blue200" css={subtitle}>
+            예약금 20,000원
+          </Text>
+          <Text typo="body11" color="gray600">
+            안전한 예약 관리를 위해 예약금 제도를 운영하고 있습니다. <br /> 예약금은 방문 시술 후
+            결제금액에서 차감해드립니다.
+          </Text>
+        </section>
+        <div css={line} />
+        <section css={section}>
+          <Text typo="body4" color="black">
+            아래 내용이 맞는지 확인해 주세요
+          </Text>
+          <section css={reservationInfo}>
+            <Text typo="subtitle1" color="black">
+              문소연 디자이너
+            </Text>
+            <Text typo="body9" color="gray400">
+              꼬꼬마 관리샵
+            </Text>
+            <div css={schedule}>
+              <Text typo="body4" color="gray400">
+                일정
+              </Text>
+              <div css={dateTime}>
+                <Text typo="body4" color="black">
+                  2024. 11. 17(일)
+                </Text>
+                <Text typo="body4" color="black">
+                  14:00
+                </Text>
+              </div>
+            </div>
+          </section>
+          <section css={reservationPrice}>
+            <div css={price}>
+              <Text typo="body9" color="black">
+                예약금
+              </Text>
+              <Text typo="body9" color="black">
+                20,000원
+              </Text>
+            </div>
+            <div css={thinLine} />
+            <div css={totalPrice}>
+              <Text typo="subtitle1" color="black">
+                지금 결제할 금액
+              </Text>
+              <Text typo="subtitle1" color="red200">
+                20,000원
+              </Text>
+            </div>
+          </section>
+        </section>
+        <div css={line} />
+        <section css={section}>
+          <section>
+            <Text tag="h2" typo="title2" color="black" css={title}>
+              예약자 정보
+            </Text>
+
+            <div css={visitorInfo}>
+              <Text typo="subtitle3" color="black">
+                고윤정
+              </Text>
+              <Text typo="subtitle3" color="black">
+                010-0000-0000
+              </Text>
+            </div>
+          </section>
+          <section css={additionalInfoBox}>
+            <div css={additionalInfo}>
+              <div css={additionalInfoButton}>
+                <Text typo="body5" color="gray600">
+                  실제 방문자가 다르신가요?
+                </Text>
+                <SelectUnfoldInactive width={12} css={arrow} />
+              </div>
+              <div css={grayLine} />
+            </div>
+            <Text tag="h3" typo="body4" color="black" css={inputTitle}>
+              실제 방문하실 분의 정보를 입력해주세요
+            </Text>
+            <Input label="방문자" placeholder="방문자 이름을 입력해주세요" css={input} />
+            <Input label="휴대폰번호" placeholder="휴대폰 번호를 입력해주세요" />
+          </section>
+          <CTAButton>예약하기</CTAButton>
+        </section>
+      </div>
+    </Layout>
+  );
+}

--- a/packages/core/design-system/src/icons/SelectUnfoldActive.tsx
+++ b/packages/core/design-system/src/icons/SelectUnfoldActive.tsx
@@ -1,6 +1,12 @@
 import type { SVGProps } from 'react';
 export const SelectUnfoldActive = (props: SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 5" {...props}>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 8 5"
+    {...props}
+    transform="rotate(180)"
+  >
     <g clipPath="url(#select_unfold_active_svg__a)">
       <path stroke="#5D86FE" strokeLinecap="round" strokeLinejoin="round" d="M7 1 4 4 1 1" />
     </g>

--- a/packages/core/design-system/src/icons/SelectUnfoldInactive.tsx
+++ b/packages/core/design-system/src/icons/SelectUnfoldInactive.tsx
@@ -2,7 +2,7 @@ import type { SVGProps } from 'react';
 export const SelectUnfoldInactive = (props: SVGProps<SVGSVGElement>) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 5" {...props}>
     <g clipPath="url(#select_unfold_inactive_svg__a)">
-      <path stroke="#E6E6E6" strokeLinecap="round" strokeLinejoin="round" d="M7 1 4 4 1 1" />
+      <path stroke="current" strokeLinecap="round" strokeLinejoin="round" d="M7 1 4 4 1 1" />
     </g>
     <defs>
       <clipPath id="select_unfold_inactive_svg__a">


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #130 

<br/>

## 📝 관련 문서 레퍼런스

- [Slack] : X
- [Notion] : X

<br/>

## 💻 주요 변경 사항은 무엇인가요?

- 예약금 결제 페이지 UI를 구현했습니다.
- SelectUnfoldInactive -> svg 속성 내부 stroke=current 로 변경
- SelectUnfoldActive -> svg 속성에 transform=rotate(180) 코드 추가

<br/>

## 📚 추가된 라이브러리

- [추가] : NO

<br/>

## 📱 결과 화면 (선택)
![예약금 결제 ui](https://github.com/user-attachments/assets/3cfe6fc2-4f8d-40d8-a12d-8209be0fb416)

<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)
- 글자 간 간격 조절을 위한 코드 한 줄만 들어있는 css가 많은데 간격 조절을 위해서 각각 스타일을 지정하는 게 맞는 건지 더 간결하게 정리하는 방법이 있는지 궁금합니다🥹
