### PR TITLE
[Feature/daengle] 사용자 일반 & 지정 견적 리스트 구분 페이지 구현

### DIFF
--- a/apps/daengle/src/components/estimate/card-list/index.tsx
+++ b/apps/daengle/src/components/estimate/card-list/index.tsx
@@ -25,9 +25,10 @@ interface UserEstimateContent {
 
 interface Props {
   estimateData: UserEstimateContent[];
+  isDesignation: boolean;
 }
 
-export function CardList({ estimateData }: Props): JSX.Element {
+export function CardList({ estimateData, isDesignation }: Props): JSX.Element {
   const router = useRouter();
 
   return (
@@ -39,7 +40,10 @@ export function CardList({ estimateData }: Props): JSX.Element {
               <Text css={nameStyle} typo="subtitle3">
                 {data.name}
               </Text>
-              <div css={distanceStyle(data.daengleMeter)}>🐾 {data.daengleMeter}m</div>
+              <div css={distanceStyle(data.daengleMeter)}>
+                {/* 상태 확인 데이터 추후 필요한 부분 */}
+                {isDesignation ? `진행 중` : `🐾 ${data.daengleMeter}m`}
+              </div>
             </div>
             <div css={cardContent}>
               <Text typo="body11" color="gray400">

--- a/apps/daengle/src/pages/estimate/index.styles.ts
+++ b/apps/daengle/src/pages/estimate/index.styles.ts
@@ -10,4 +10,63 @@ export const wrapper = css`
 export const headerContainer = css`
   padding: 18px 34px;
   margin-top: 4px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+`;
+
+export const line = css`
+  width: 100%;
+  height: 1px;
+  background: ${theme.colors.gray100};
+`;
+
+export const modalItem = (isDesignation: boolean) => css`
+  width: 100%;
+  text-align: center;
+  border: none;
+  color: ${isDesignation ? theme.colors.blue200 : theme.colors.gray400};
+  cursor: pointer;
+
+  :hover {
+    color: ${theme.colors.blue200};
+  }
+`;
+
+export const modalOverlay = css`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: ${theme.colors.grayOpacity300};
+  z-index: 100;
+`;
+
+export const modalContent = css`
+  position: fixed;
+  width: 100%;
+  max-width: ${theme.size.maxWidth};
+  justify-content: center;
+  align-items: center;
+  bottom: 0;
+  background: white;
+  border-radius: 20px 20px 0 0;
+  padding: 21px 18px;
+  z-index: 101;
+  animation: slideUp 0.3s ease-in-out;
+  display: flex;
+  flex-direction: column;
+  gap: 19px;
+
+  @keyframes slideUp {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
 `;

--- a/packages/core/design-system/src/icons/SelectUnfoldInactive.tsx
+++ b/packages/core/design-system/src/icons/SelectUnfoldInactive.tsx
@@ -1,8 +1,25 @@
 import type { SVGProps } from 'react';
-export const SelectUnfoldInactive = (props: SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 5" {...props}>
+
+interface Props extends SVGProps<SVGSVGElement> {
+  color?: string;
+}
+
+export const SelectUnfoldInactive = ({
+  color = '#E6E6E6',
+  width = '8px',
+  height = '5px',
+  ...props
+}: Props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 8 5"
+    width={width}
+    height={height}
+    {...props}
+  >
     <g clipPath="url(#select_unfold_inactive_svg__a)">
-      <path stroke="#E6E6E6" strokeLinecap="round" strokeLinejoin="round" d="M7 1 4 4 1 1" />
+      <path stroke={color} strokeLinecap="round" strokeLinejoin="round" d="M7 1 4 4 1 1" />
     </g>
     <defs>
       <clipPath id="select_unfold_inactive_svg__a">


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #159 

<br/>

## 📝 관련 문서 레퍼런스

- [Slack] : X
- [Notion] : X

<br/>

## 💻 주요 변경 사항은 무엇인가요?

- 헤더 선택에 따라 지정 견적 리스트를 구분할 수 있도록 구현하였습니다

<br/>

## 📚 추가된 라이브러리

- [추가] : NO

<br/>

## 📱 결과 화면 (선택)

https://github.com/user-attachments/assets/8375b2ac-6739-43c2-824b-1eb2d8092f8b


<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

- 지정 예약서의 진행 상황에 대한 데이터를 받아온 이후에 데이터 수정이 있을 예정입니다.
