### PR TITLE
[Story/groomer] 미용사 견적서 전송 완료 상태 화면 구현

### DIFF
--- a/apps/groomer/src/pages/estimate/index.ts
+++ b/apps/groomer/src/pages/estimate/index.ts
@@ -1,0 +1,1 @@
+export * from './success';

--- a/apps/groomer/src/pages/estimate/success/index.styles.ts
+++ b/apps/groomer/src/pages/estimate/success/index.styles.ts
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+
+export const wrapper = css`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const content = css`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+`;
+
+export const title = css`
+  margin: 38px 0 0 0;
+`;
+
+export const subtitle = css`
+  margin: 12px 0 47px 0;
+`;

--- a/apps/groomer/src/pages/estimate/success/index.tsx
+++ b/apps/groomer/src/pages/estimate/success/index.tsx
@@ -1,0 +1,37 @@
+import { useRouter } from 'next/router';
+import { Layout, RoundButton, Text } from '@daengle/design-system';
+import { TransmissionComplete } from '@daengle/design-system/icons';
+import { ROUTES } from '~/constants/commons/routes';
+import { content, subtitle, title, wrapper } from './index.styles';
+
+export default function Pending() {
+  const router = useRouter();
+
+  return (
+    <Layout>
+      <section css={wrapper}>
+        <div css={content}>
+          <TransmissionComplete />
+
+          <div css={title}>
+            <Text typo="title2" color="black">
+              {`견적서 전송이 완료되었어요!\n응답이 도착하면 알려드릴게요`}
+            </Text>
+          </div>
+
+          <div css={subtitle}>
+            <Text typo="body9" color="gray500">
+              알림톡으로 응답이 전송됩니다
+            </Text>
+          </div>
+
+          <RoundButton service="partner" size="S" onClick={() => router.push(ROUTES.HOME)}>
+            <Text typo="body4" color="white">
+              메인으로
+            </Text>
+          </RoundButton>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/packages/core/design-system/public/icons/transmission_complete.svg
+++ b/packages/core/design-system/public/icons/transmission_complete.svg
@@ -1,0 +1,4 @@
+<svg width="90" height="90" viewBox="0 0 90 90" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="45" cy="45" r="44" stroke="#84DACF" stroke-width="2"/>
+<path d="M23 48.5L35.3563 61L66 30" stroke="#84DACF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/core/design-system/src/icons/TransmissionComplete.tsx
+++ b/packages/core/design-system/src/icons/TransmissionComplete.tsx
@@ -1,0 +1,16 @@
+import type { SVGProps } from 'react';
+interface Props extends SVGProps<SVGSVGElement> {
+  color?: string;
+}
+export const TransmissionComplete = ({ color = '#84DACF', ...props }: Props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={90} height={90} fill="none" {...props}>
+    <circle cx={45} cy={45} r={44} stroke="#84DACF" strokeWidth={2} />
+    <path
+      stroke={color}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M23 48.5 35.356 61 66 30"
+    />
+  </svg>
+);

--- a/packages/core/design-system/src/icons/index.ts
+++ b/packages/core/design-system/src/icons/index.ts
@@ -14,3 +14,4 @@ export * from './ImageUploadPlus';
 export * from './RegistrationPending';
 export * from './SelectUnfoldActive';
 export * from './SelectUnfoldInactive';
+export * from './TransmissionComplete';


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #9 

<br/>

## 📝 관련 문서 레퍼런스

- [Slack] : X
- [Notion] : X

<br/>

## 💻 주요 변경 사항은 무엇인가요?

- 미용사 견적서 전송 완료 상태 페이지를 구현하였습니다

<br/>

## 📚 추가된 라이브러리

- [추가] : NO

<br/>

## 📱 결과 화면 (선택)

<img src="https://github.com/user-attachments/assets/5e5cd23f-8484-4deb-a845-a4d96e50e336" width="200px" />
<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

- 
