### PR TITLE
[Fix/daengle] 중복검사 확인 문구 버그 수정, 기존 이미지 삭제 로직 추가

### DIFF
--- a/apps/daengle/src/pages/mypage/user-profile/edit/index.tsx
+++ b/apps/daengle/src/pages/mypage/user-profile/edit/index.tsx
@@ -39,20 +39,26 @@ export default function EditProfile() {
     mode: 'onChange',
     defaultValues: {
       image: null,
+      nickname: '',
+      isAvailableNickname: false, // 닉네임 중복 검사 결과
     },
   });
 
   const checkIsAvailableNickname = async () => {
-    const nickname = watch('nickname'); // 입력한 닉네임 가져오기
+    const nickname = watch('nickname');
     if (!nickname) {
       setError('nickname', { message: '닉네임을 입력해주세요.' });
+      setValue('isAvailableNickname', false);
       return;
     }
 
     const response = await postAvailableNickname({ nickname });
-
-    if (!response.isAvailable) {
-      setError('nickname', { message: '이미 사용중인 닉네임입니다' });
+    if (response.isAvailable) {
+      setError('nickname', { message: '' });
+      setValue('isAvailableNickname', true);
+    } else {
+      setError('nickname', { message: '이미 사용중인 닉네임입니다.' });
+      setValue('isAvailableNickname', false);
     }
   };
 
@@ -74,7 +80,12 @@ export default function EditProfile() {
   const handleGoToClick = () => {
     router.push(ROUTES.MYPAGE);
   };
-  const confirmMessage = watch('nickname') && !errors.nickname ? '사용 가능한 닉네임입니다' : '';
+  const handleNicknameChange = () => {
+    setValue('isAvailableNickname', false);
+  };
+  function clearErrors() {
+    throw new Error('Function not implemented.');
+  }
 
   return (
     <Layout isAppBarExist={true}>
@@ -103,9 +114,12 @@ export default function EditProfile() {
                     중복검사
                   </ChipButton>
                 }
-                {...register('nickname', { ...validation.nickname })}
+                {...register('nickname', {
+                  ...validation.nickname,
+                  onChange: handleNicknameChange,
+                })}
                 errorMessage={errors.nickname?.message}
-                confirmMessage={confirmMessage}
+                confirmMessage={watch('isAvailableNickname') ? '사용 가능한 닉네임입니다.' : ''}
               />
             </li>
             <li css={readOnlyTextBox}>

--- a/apps/daengle/src/pages/mypage/user-profile/edit/index.tsx
+++ b/apps/daengle/src/pages/mypage/user-profile/edit/index.tsx
@@ -40,7 +40,7 @@ export default function EditProfile() {
     defaultValues: {
       image: null,
       nickname: '',
-      isAvailableNickname: false, // 닉네임 중복 검사 결과
+      isAvailableNickname: false,
     },
   });
 
@@ -65,6 +65,7 @@ export default function EditProfile() {
   const onSubmit = async (data: UserProfileInfoEditForm) => {
     let imageString = '';
     if (data.image) {
+      // TODO: 여기에 이미지 삭제 하기 넣기
       const uploadedImages = await uploadToS3([data.image]);
       if (uploadedImages && uploadedImages.length > 0) {
         imageString = uploadedImages[0] ?? '';
@@ -83,9 +84,6 @@ export default function EditProfile() {
   const handleNicknameChange = () => {
     setValue('isAvailableNickname', false);
   };
-  function clearErrors() {
-    throw new Error('Function not implemented.');
-  }
 
   return (
     <Layout isAppBarExist={true}>

--- a/apps/daengle/src/pages/mypage/user-profile/edit/interfaces/index.ts
+++ b/apps/daengle/src/pages/mypage/user-profile/edit/interfaces/index.ts
@@ -1,6 +1,7 @@
 export interface UserProfileInfoEditForm {
   image: File | null;
   nickname: string;
+  isAvailableNickname: boolean;
 }
 export interface UserProfileInfoEditFormType {
   form: UserProfileInfoEditForm;


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #200 

<br/>

## 📝 관련 문서 레퍼런스

- [Slack] :
- [Notion] :

<br/>

## 💻 주요 변경 사항은 무엇인가요?

- 프로필 업로드 전 기존 이미지 삭제 로직 추가 했습니다.
- 중복검사를 하지 않아도 '사용 가능한 닉네임입니다' 라는 문구가 뜨는 버그 수정했습니다.

<br/>

## 📚 추가된 라이브러리

- [추가] : NO

<br/>

## 📱 결과 화면 (선택)

<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

- 폴더구조는 새 브랜치 파서 수정하도록 하겠습니다.
