### PR TITLE
[Task/github] 빌드 에러 검사 workflow 추가

### DIFF
--- a/.github/workflows/check-build-error.yml
+++ b/.github/workflows/check-build-error.yml
@@ -1,0 +1,46 @@
+name: 🛠 Build and Test on PR to develop or main
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches:
+      - develop
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 👀 Checkout Code
+        uses: actions/checkout@v3
+
+      - name: ✨ Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.9.0
+
+      - name: ⭐️ Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.17.0'
+
+      - name: 🏎 Cache Dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: 📦 Install Dependencies
+        run: |
+          pnpm install
+
+      - name: 🚀 Build Project
+        run: |
+          pnpm build # 빌드 명령어
+
+      - name: 🏁 Finish
+        run: |
+          echo "🎉 빌드 성공 🎉 "


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #218 

<br/>

## 📝 관련 문서 레퍼런스

- [Slack] : X
- [Notion] : X

<br/>

## 💻 주요 변경 사항은 무엇인가요?

- develop 또는 main 브랜치에 머지 전 빌드 에러를 검사하는 workflow를 추가했습니다.
- develop 또는 main 브랜치에 머지하는 PR을 올리거나 수정할 때 자동으로 검사를 진행합니다.

<br/>

## 📚 추가된 라이브러리

- [추가] : NO

<br/>

## 📱 결과 화면 (선택)

<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

- X
