### PR TITLE
[Fix/daengle] 중복검사 로직 수정 및 수정하기 버튼 활성화 로직 수정

### DIFF
--- a/apps/daengle/src/pages/mypage/user-profile/edit/index.tsx
+++ b/apps/daengle/src/pages/mypage/user-profile/edit/index.tsx
@@ -63,7 +63,6 @@ export default function EditProfile() {
   };
 
   const onSubmit = async (data: UserProfileInfoEditForm) => {
-    if (!isValid) return;
     let imageString = '';
 
     // 기존 이미지 삭제

--- a/apps/daengle/src/pages/mypage/user-profile/edit/index.tsx
+++ b/apps/daengle/src/pages/mypage/user-profile/edit/index.tsx
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import { useForm } from 'react-hook-form';
 import { AppBar, ChipButton, CTAButton, Input, Layout, Text } from '@daengle/design-system';
 import {
@@ -25,9 +26,9 @@ export default function EditProfile() {
     handleSubmit,
     watch,
     register,
-
     setError,
     setValue,
+    clearErrors,
     formState: { errors, isValid },
   } = useForm<UserProfileInfoEditForm>({
     mode: 'onChange',
@@ -46,15 +47,14 @@ export default function EditProfile() {
       return;
     }
 
-    if (nickname.length < 2) {
-      setError('nickname', { message: '2글자 이상 입력해 주세요' });
+    if (nickname.length < 2 || nickname.length > 10) {
+      setError('nickname', { message: '닉네임은 2글자 이상 10글자 미만으로 작성해 주세요' });
+      setValue('isAvailableNickname', false);
       return;
     }
 
     const response = await postAvailableNickname({ nickname });
-
     if (response.isAvailable) {
-      setError('nickname', { message: '' });
       setValue('isAvailableNickname', true);
     } else {
       setError('nickname', { message: '이미 사용중인 닉네임입니다.' });
@@ -63,6 +63,7 @@ export default function EditProfile() {
   };
 
   const onSubmit = async (data: UserProfileInfoEditForm) => {
+    if (!isValid) return;
     let imageString = '';
 
     // 기존 이미지 삭제
@@ -87,13 +88,11 @@ export default function EditProfile() {
     if (imageString != undefined) {
       patchUserInfo({ ...data, image: imageString });
     }
-  };
-
-  const handleGoToClick = () => {
     router.push(ROUTES.MYPAGE);
   };
   const handleNicknameChange = () => {
     setValue('isAvailableNickname', false);
+    clearErrors('nickname');
   };
 
   return (
@@ -157,7 +156,7 @@ export default function EditProfile() {
             </li>
           </ul>
 
-          <CTAButton type="submit" onClick={handleGoToClick} disabled={!isValid}>
+          <CTAButton type="submit" disabled={!isValid || !watch('isAvailableNickname')}>
             수정하기
           </CTAButton>
         </form>
@@ -175,14 +174,16 @@ export const profileImageWrapper = css`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+
   margin: 32px 0 40px;
 `;
 export const inputWrapper = css`
-  margin: 0;
-  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 32px;
+
+  margin: 0;
+  padding: 0;
 `;
 export const nickNameWrapper = css`
   display: flex;

--- a/apps/daengle/src/pages/mypage/user-profile/edit/index.tsx
+++ b/apps/daengle/src/pages/mypage/user-profile/edit/index.tsx
@@ -46,7 +46,13 @@ export default function EditProfile() {
       return;
     }
 
+    if (nickname.length < 2) {
+      setError('nickname', { message: '2글자 이상 입력해 주세요' });
+      return;
+    }
+
     const response = await postAvailableNickname({ nickname });
+
     if (response.isAvailable) {
       setError('nickname', { message: '' });
       setValue('isAvailableNickname', true);

--- a/apps/daengle/src/queries/auth/index.ts
+++ b/apps/daengle/src/queries/auth/index.ts
@@ -46,13 +46,7 @@ export const usePostJoinWithoutPetMutation = () => {
 export const usePostAvailableNicknameMutation = () => {
   return useMutation({
     mutationKey: QUERY_KEYS.POST_AVAILABLE_NICKNAME,
-    mutationFn: async (body: PostAvailableNicknameRequestBody) => {
-      try {
-        return await postAvailableNickname(body);
-      } catch (error) {
-        throw new Error(String(error));
-      }
-    },
+    mutationFn: postAvailableNickname,
   });
 };
 

--- a/packages/services/src/apis/config/index.ts
+++ b/packages/services/src/apis/config/index.ts
@@ -14,7 +14,8 @@ export const createHttpClient = ({ baseURL, role }: Props) => {
 
   // TODO: 추후 로그인 로직 변경
   api.interceptors.request.use((config) => {
-    const token = localStorage.getItem('accessToken');
+    // const token = localStorage.getItem('accessToken');
+    const token = process.env.NEXT_PUBLIC_TOKEN;
 
     if (token) {
       config.headers['Authorization'] = `Bearer ${token}`;

--- a/packages/services/src/apis/config/index.ts
+++ b/packages/services/src/apis/config/index.ts
@@ -14,8 +14,7 @@ export const createHttpClient = ({ baseURL, role }: Props) => {
 
   // TODO: 추후 로그인 로직 변경
   api.interceptors.request.use((config) => {
-    // const token = localStorage.getItem('accessToken');
-    const token = process.env.NEXT_PUBLIC_TOKEN;
+    const token = localStorage.getItem('accessToken');
 
     if (token) {
       config.headers['Authorization'] = `Bearer ${token}`;


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #220 

<br/>

## 📝 관련 문서 레퍼런스

- [Slack] :
- [Notion] :

<br/>

## 💻 주요 변경 사항은 무엇인가요?

- 수정된 닉네임 api에 따라 에러/컨펌 메세지 띄우기
- 중복검사를 수행하지 않아도 프로필 수정이 가능한 버그 수정
- 수정하기 버튼이 비활성화된 상태에서 버튼을 눌러도 작동하여 메인 페이지로 다시 이동하는 버그 수정

<br/>

## 📚 추가된 라이브러리

- [추가] : NO

<br/>

## 📱 결과 화면 (선택)

<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

-
