### PR TITLE
[Design/daengle] 사용자 예약 리스트 & 상세 조회 퍼블리싱

### DIFF
--- a/apps/daengle/src/components/reservations/groomer-list/index.styles.ts
+++ b/apps/daengle/src/components/reservations/groomer-list/index.styles.ts
@@ -1,0 +1,21 @@
+import { css } from '@emotion/react';
+
+export const wrapper = css`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  position: relative;
+  overflow-y: scroll;
+
+  width: 100%;
+  height: 100%;
+  padding: 12px 18px 0 0;
+`;
+
+export const bottom = css`
+  position: absolute;
+  bottom: 0;
+
+  width: 100%;
+  height: 18px;
+`;

--- a/apps/daengle/src/components/reservations/groomer-list/index.tsx
+++ b/apps/daengle/src/components/reservations/groomer-list/index.tsx
@@ -1,0 +1,43 @@
+import { Empty } from '~/components/reviews';
+
+import { wrapper } from './index.styles';
+import { ReservationsCard } from '../reservations-card';
+
+export function GroomerList() {
+  const data = [
+    {
+      estimateId: 3,
+      groomerName: '유레카미용사',
+      petName: '시바견',
+      petImageUrl: '',
+      shopName: '유레카 미용실',
+      reservedDate: '2024-12-12 21:34:13',
+    },
+    {
+      estimateId: 4,
+      groomerName: '유레카미용사',
+      petName: '시바견',
+      petImageUrl: '',
+      shopName: '유레카 미용실',
+      reservedDate: '2024-12-12 21:34:13',
+    },
+    {
+      estimateId: 5,
+      groomerName: '유레카미용사',
+      petName: '시바견',
+      petImageUrl: '',
+      shopName: '유레카 미용실',
+      reservedDate: '2024-12-12 21:34:13',
+    },
+  ];
+
+  return (
+    <div css={wrapper}>
+      {data ? (
+        data?.map((item) => <ReservationsCard item={item} />)
+      ) : (
+        <Empty title="예약 내역이 없어요" />
+      )}
+    </div>
+  );
+}

--- a/apps/daengle/src/components/reservations/index.ts
+++ b/apps/daengle/src/components/reservations/index.ts
@@ -1,0 +1,2 @@
+export * from './groomer-list';
+export * from './vet-list';

--- a/apps/daengle/src/components/reservations/reservations-card/index.styles.ts
+++ b/apps/daengle/src/components/reservations/reservations-card/index.styles.ts
@@ -1,0 +1,41 @@
+import { css } from '@emotion/react';
+import { theme } from '@daengle/design-system';
+
+export const wrapper = css`
+  display: flex;
+
+  width: 100%;
+  padding: 12px 12px 12px 18px;
+  border-radius: 0 65px 65px 0;
+
+  background: ${theme.colors.white};
+
+  cursor: pointer;
+
+  img {
+    border-radius: 50%;
+  }
+`;
+
+export const infoWrapper = css`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  justify-content: center;
+  gap: 4px;
+
+  width: 100%;
+`;
+
+export const top = css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const image = css`
+  border-radius: 50%;
+  object-fit: cover;
+
+  background-color: ${theme.colors.gray200};
+`;

--- a/apps/daengle/src/components/reservations/reservations-card/index.tsx
+++ b/apps/daengle/src/components/reservations/reservations-card/index.tsx
@@ -1,0 +1,71 @@
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import { Tag, Text } from '@daengle/design-system';
+import { DefaultImage } from '@daengle/design-system/icons';
+import { ROUTES } from '~/constants/commons';
+import { image, infoWrapper, top, wrapper } from './index.styles';
+import dayjs from 'dayjs';
+import 'dayjs/locale/ko';
+
+interface Props {
+  item: GroomerItem | VetItem;
+}
+
+interface GroomerItem {
+  estimateId: number;
+  groomerName: string;
+  petName: string;
+  petImageUrl: string;
+  shopName: string;
+  reservedDate: string;
+}
+
+interface VetItem {
+  estimateId: number;
+  vetName: string;
+  petName: string;
+  petImageUrl: string;
+  reservedDate: string;
+}
+
+export function ReservationsCard({ item }: Props) {
+  const router = useRouter();
+  const { service } = router.query; // service: 'groomer' or 'vet'
+
+  // 타입 가드로 데이터 구조 구분
+  const isGroomer = (item: GroomerItem | VetItem): item is GroomerItem => 'groomerName' in item;
+
+  return (
+    <div css={wrapper} onClick={() => router.push(ROUTES.RESERVATIONS_DETAIL(item.estimateId))}>
+      <div css={infoWrapper}>
+        <div css={top}>
+          <Text typo="subtitle1" color="black">
+            {isGroomer(item) ? item.groomerName : item.vetName}
+          </Text>
+
+          <Tag variant="line">
+            <Text typo="body2" color="blue200">
+              {item.petName}
+            </Text>
+          </Tag>
+        </div>
+
+        {isGroomer(item) && (
+          <Text typo="body11" color="gray400">
+            {item.shopName}
+          </Text>
+        )}
+
+        <Text typo="body12" color="gray600">
+          {dayjs(item.reservedDate).locale('ko').format('YYYY.MM.DD(ddd) • HH:mm')}
+        </Text>
+      </div>
+
+      {item.petImageUrl ? (
+        <Image src={item.petImageUrl} alt="recipient" width={70} height={70} css={image} />
+      ) : (
+        <DefaultImage width={70} height={70} css={image} />
+      )}
+    </div>
+  );
+}

--- a/apps/daengle/src/components/reservations/vet-list/index.styles.ts
+++ b/apps/daengle/src/components/reservations/vet-list/index.styles.ts
@@ -1,0 +1,21 @@
+import { css } from '@emotion/react';
+
+export const wrapper = css`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  position: relative;
+  overflow-y: scroll;
+
+  width: 100%;
+  height: 100%;
+  padding: 12px 18px 0 0;
+`;
+
+export const bottom = css`
+  position: absolute;
+  bottom: 0;
+
+  width: 100%;
+  height: 18px;
+`;

--- a/apps/daengle/src/components/reservations/vet-list/index.tsx
+++ b/apps/daengle/src/components/reservations/vet-list/index.tsx
@@ -1,0 +1,40 @@
+import { Empty } from '~/components/reviews';
+
+import { wrapper } from './index.styles';
+import { ReservationsCard } from '../reservations-card';
+
+export function VetList() {
+  const data = [
+    {
+      estimateId: 3,
+      vetName: '유레카병원',
+      petName: '시바견',
+      petImageUrl: '',
+      reservedDate: '2024-12-12 21:34:13',
+    },
+    {
+      estimateId: 4,
+      vetName: '유레카병원',
+      petName: '시바견',
+      petImageUrl: '',
+      reservedDate: '2024-12-12 21:34:13',
+    },
+    {
+      estimateId: 5,
+      vetName: '유레카병원',
+      petName: '시바견',
+      petImageUrl: '',
+      reservedDate: '2024-12-12 21:34:13',
+    },
+  ];
+
+  return (
+    <div css={wrapper}>
+      {data ? (
+        data?.map((item) => <ReservationsCard item={item} />)
+      ) : (
+        <Empty title="예약 내역이 없어요" />
+      )}
+    </div>
+  );
+}

--- a/apps/daengle/src/constants/commons/routes.ts
+++ b/apps/daengle/src/constants/commons/routes.ts
@@ -30,6 +30,7 @@ export const ROUTES = {
 
   // Reservations
   RESERVATIONS: '/reservations',
+  RESERVATIONS_DETAIL: (estimateId: number) => `reservations/${estimateId}`,
 
   // Chat
   CHATS: '/chats',

--- a/apps/daengle/src/pages/reservations/[id]/index.tsx
+++ b/apps/daengle/src/pages/reservations/[id]/index.tsx
@@ -1,0 +1,203 @@
+import { AppBar, Layout, RoundButton, Text } from '@daengle/design-system';
+import { theme } from '@daengle/design-system';
+import { css } from '@emotion/react';
+import { PartnersInfo, Receipt } from '~/components/estimate';
+import { useRouter } from 'next/router';
+import { useEstimateCareDetailQuery, useEstimateGroomingDetailQuery } from '~/queries/estimate';
+import dayjs from 'dayjs';
+import 'dayjs/locale/ko';
+import { UserEstimateCareDetailData, UserEstimateGroomingDetailData } from '~/interfaces/estimate';
+import {
+  UserEstimateCareDetailRequestParams,
+  UserEstimateGroomingDetailRequestParams,
+} from '~/models/estimate';
+
+type DetailData = UserEstimateGroomingDetailData | UserEstimateCareDetailData;
+
+export default function Detail() {
+  const router = useRouter();
+  const { id, type } = router.query;
+  const estimateId = Number(id);
+
+  const isGrooming = type === 'grooming';
+  const isCare = type === 'care';
+
+  const groomingParams: UserEstimateGroomingDetailRequestParams = {
+    groomingEstimateId: estimateId,
+  };
+  const careParams: UserEstimateCareDetailRequestParams = { careEstimateId: estimateId };
+  //TODO: 예약 조회로 api 변환
+  const {
+    data: groomingData,
+    isLoading: groomerLoading,
+    error: groomerError,
+  } = useEstimateGroomingDetailQuery(groomingParams, isGrooming);
+
+  const {
+    data: careData,
+    isLoading: careLoading,
+    error: careError,
+  } = useEstimateCareDetailQuery(careParams, isCare);
+
+  if (groomerLoading || careLoading) return <div>Loading...</div>;
+
+  if (groomerError || careError || (!groomingData && !careData)) {
+    return <div>데이터를 불러오지 못했습니다.</div>;
+  }
+
+  let detailData: DetailData;
+  if (isGrooming && groomingData) {
+    detailData = groomingData;
+  } else if (isCare && careData) {
+    detailData = careData;
+  } else {
+    return <div>유효하지 않은 type 입니다.</div>;
+  }
+
+  const isGroomingDetail = (data: DetailData): data is UserEstimateGroomingDetailData =>
+    'groomerId' in data;
+  const formattedDate = dayjs(detailData.reservedDate).locale('ko').format('YYYY.MM.DD(ddd) HH:mm');
+  const introduction = detailData.introduction || '소개글 없음';
+
+  if (isGroomingDetail(detailData)) {
+    const designerData = {
+      id: estimateId,
+      name: detailData.name,
+      shopName: detailData.shopName,
+      image: detailData.image,
+      daengleMeter: detailData.daengleMeter,
+      tags: detailData?.tags || [],
+    };
+
+    // TODO: null값에 대한 일괄 처리 필요
+    const overallOpinion = detailData.overallOpinion || '없음';
+
+    return (
+      <Layout isAppBarExist={false}>
+        <AppBar />
+        <div css={wrapper}>
+          <div css={header}>
+            <Text typo="title1">견적 상세</Text>
+          </div>
+          <PartnersInfo profile={designerData} />
+          <section css={section}>
+            <Text typo="body1">소개</Text>
+            <Text typo="body10" tag="div">
+              {introduction}
+            </Text>
+          </section>
+          <Receipt
+            items={[
+              { title: '지역', receipt: detailData.address },
+              { title: '일정', receipt: formattedDate },
+              { title: '서비스', receipt: detailData.desiredStyle },
+              { title: '추가 소견', receipt: overallOpinion, typo: 'body4' },
+            ]}
+          />
+          <div css={buttonGroup}>
+            <RoundButton variant="primary" size="S" fullWidth>
+              <Text typo="body1" color="white">
+                채팅 문의
+              </Text>
+            </RoundButton>
+            <RoundButton
+              variant="primary"
+              size="M"
+              fullWidth
+              onClick={() => alert('예약금 결제를 진행합니다.')}
+            >
+              <Text typo="body1" color="white">
+                예약 취소
+              </Text>
+            </RoundButton>
+          </div>
+        </div>
+      </Layout>
+    );
+  } else {
+    const vetData = {
+      id: detailData.careEstimateId,
+      name: detailData.name,
+      shopName: detailData.name || '병원 정보 없음',
+      image: detailData.image,
+      daengleMeter: detailData.daengleMeter,
+      tags: detailData?.tags || [],
+    };
+    return (
+      <Layout isAppBarExist={false}>
+        <AppBar />
+        <div css={wrapper}>
+          <div css={header}>
+            <Text typo="title1">진료 상세</Text>
+          </div>
+          <PartnersInfo profile={vetData} />
+          <section css={section}>
+            <Text typo="body1">소개</Text>
+            <Text typo="body10" tag="div">
+              {introduction}
+            </Text>
+          </section>
+          <Receipt
+            items={[
+              { title: '지역', receipt: detailData.address },
+              { title: '일정', receipt: formattedDate, hasLine: true, addTitle: '종합소견' },
+              { title: '추정 병명', receipt: detailData.cause },
+              { title: '추정 원인', receipt: detailData.cause },
+              {
+                title: '예상 진료',
+                receipt: detailData.treatment || '내원하여 확인해 주세요.',
+                typo: 'body4',
+              },
+            ]}
+          />
+          <div css={buttonGroup}>
+            <RoundButton variant="primary" size="S" fullWidth>
+              <Text typo="body1" color="white">
+                채팅 문의
+              </Text>
+            </RoundButton>
+            <RoundButton
+              variant="primary"
+              size="M"
+              fullWidth
+              onClick={() => alert('예약금 결제를 진행합니다.')}
+            >
+              <Text typo="body1" color="white">
+                예약금 결제
+              </Text>
+            </RoundButton>
+          </div>
+        </div>
+      </Layout>
+    );
+  }
+}
+
+const wrapper = css`
+  padding-top: ${theme.size.appBarHeight};
+
+  background-color: ${theme.colors.background};
+`;
+
+const header = css`
+  display: flex;
+  align-items: center;
+
+  margin: 18px;
+`;
+
+const section = css`
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+
+  margin: 18px 18px 32px;
+`;
+
+const buttonGroup = css`
+  display: flex;
+  justify-content: center;
+  gap: 13px;
+
+  margin: 32px 18px 18px;
+`;

--- a/apps/daengle/src/pages/reservations/index.tsx
+++ b/apps/daengle/src/pages/reservations/index.tsx
@@ -1,0 +1,63 @@
+import { css } from '@emotion/react';
+import { Layout, Tabs, Text, theme } from '@daengle/design-system';
+import { GroomerList, VetList } from '~/components/reservations';
+import { GNB } from '~/components/commons';
+
+const TABS = [
+  {
+    id: 'groomer',
+    label: '미용사',
+  },
+  {
+    id: 'vet',
+    label: '병원',
+  },
+];
+
+export default function Reservations() {
+  const renderContent = (activeTabId: string) => {
+    switch (activeTabId) {
+      case 'groomer':
+        return <GroomerList />;
+      case 'vet':
+        return <VetList />;
+      default:
+        return <GroomerList />;
+    }
+  };
+
+  return (
+    <Layout isAppBarExist={false}>
+      <section css={wrapper}>
+        <Text tag="h1" typo="title1" color="black">
+          예약
+        </Text>
+
+        <div css={content}>
+          <Tabs tabs={TABS} renderContent={renderContent} />
+        </div>
+        <GNB />
+      </section>
+    </Layout>
+  );
+}
+
+const wrapper = css`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+
+  padding: calc(${theme.size.appBarHeight} - 18px) 0 0 0;
+
+  background: ${theme.colors.background};
+
+  h1 {
+    margin: 0 18px;
+  }
+`;
+
+const content = css`
+  width: 100%;
+  height: 100%;
+  margin: 34px 0 0;
+`;

--- a/packages/core/design-system/src/components/tag/index.styles.ts
+++ b/packages/core/design-system/src/components/tag/index.styles.ts
@@ -23,8 +23,6 @@ export const solid = css`
 
 export const line = css`
   border: 1px solid ${theme.colors.blue200};
-
-  background: ${theme.colors.blue100};
 `;
 
 export const ghost = css`


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #272 

<br/>

## 📝 관련 문서 레퍼런스

- [Slack] : X
- [Notion] : https://www.notion.so/981021/1592efd96e69803987d7ca84cfae1504?pvs=4#2a35b331afe348ea8941241e04a9b391

<br/>

## 💻 주요 변경 사항은 무엇인가요?

- 사용자 예약 리스트 & 상세 조회 화면을 구현하였습니다

<br/>

## 📚 추가된 라이브러리

- [추가] : NO

<br/>

## 📱 결과 화면 (선택)
<img width="200" alt="스크린샷 2024-12-14 오후 3 31 04" src="https://github.com/user-attachments/assets/5c4e677a-1086-4d2f-9aaf-e80f2e97839f" />
<img width="200" alt="스크린샷 2024-12-14 오후 3 30 58" src="https://github.com/user-attachments/assets/21085267-8071-45ac-af35-e3c5e8dc811e" />


<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

- 세부적인 컴포넌트 수정은 api 연동 시 함께 하도록 하겠습니다
