### PR TITLE
[Design/daengle] 미용사 상세 페이지 퍼블리싱

### DIFF
--- a/apps/daengle/src/pages/groomers/[groomerId]/index.tsx
+++ b/apps/daengle/src/pages/groomers/[groomerId]/index.tsx
@@ -1,18 +1,17 @@
 // 미용사 상세정보
 
-import { AppBar, Layout, Text, theme } from '@daengle/design-system';
-import { DefaultProfile } from '@daengle/design-system/icons';
+import { AppBar, Layout, RoundButton, Text, TextButton, theme } from '@daengle/design-system';
+import { ButtonTextButtonArrow, DefaultProfile, ToolTip } from '@daengle/design-system/icons';
 import { css } from '@emotion/react';
 
 export default function GroomerInfo() {
   return (
     <Layout>
       <AppBar />
-      <Text typo="title1">상세보기</Text>
-      <section>
-        <div css={groomerProfile}>
+      <section css={topSection}>
+        <Text typo="title1">상세보기</Text>
+        <section css={groomerProfile}>
           <DefaultProfile width={101} height={117} css={imageStyle} />
-
           <div css={infoBox}>
             <Text typo="title2">문소연 디자이너</Text>
             <div css={tags}>
@@ -23,17 +22,58 @@ export default function GroomerInfo() {
                 #노견
               </Text>
             </div>
-            <div css={myShop}>
+            <TextButton icons={{ suffix: <ButtonTextButtonArrow width={6} /> }}>
               <Text typo="body9" color="gray500">
                 꼬꼬마 관리샵
               </Text>
-            </div>
+            </TextButton>
           </div>
+        </section>
+        <section css={infoText}>
+          <Text typo="body1">소개</Text>
+          <Text typo="body10">
+            모든 견종의 가위컷에 자신이 있으며, 특히, 푸들 테디베어컷, 비숑 귀툭튀컷, 포메 곰돌이컷
+            등 디자인컷 완성도에 자신이 있습니다.
+          </Text>
+        </section>
+        <section css={daengleMeter}>
+          <div css={textBox}>
+            <Text typo="body1">댕글미터</Text>
+            <ToolTip width={14} />
+            <Text typo="body1" color="red200" css={meter}>
+              43m
+            </Text>
+          </div>
+          <div css={graph} />
+        </section>
+        <div css={button}>
+          <RoundButton fullWidth={true}>바로 예약</RoundButton>
+          <RoundButton fullWidth={true}>채팅하기</RoundButton>
+        </div>
+      </section>
+      <section css={bottomSection}>
+        <div css={menu}>
+          <div css={review}>
+            <Text typo="subtitle1">받은 리뷰</Text>
+            <Text typo="subtitle1">38</Text>
+          </div>
+          <ButtonTextButtonArrow width={6} />
+        </div>
+        <div css={line} />
+        <div css={menu}>
+          <Text typo="subtitle1">포트폴리오</Text>
+          <ButtonTextButtonArrow width={6} />
         </div>
       </section>
     </Layout>
   );
 }
+
+const topSection = css`
+  border-bottom: 7px solid ${theme.colors.gray100};
+
+  padding: 18px 18px 24px;
+`;
 
 const groomerProfile = css`
   display: flex;
@@ -42,7 +82,6 @@ const groomerProfile = css`
 
   width: 100%;
   height: 153px;
-  border-bottom: 1px solid ${theme.colors.gray200};
 `;
 
 const imageStyle = css`
@@ -71,4 +110,66 @@ const tag = css`
   border-radius: 14px;
 `;
 
-const myShop = css``;
+const infoText = css`
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+
+  margin-bottom: 24px;
+`;
+
+const meter = css`
+  margin-left: 6px;
+`;
+
+const graph = css`
+  width: 100%;
+  height: 14px;
+  border-radius: 10px;
+
+  background-color: ${theme.colors.gray100};
+`;
+
+const button = css`
+  display: flex;
+  justify-content: center;
+  gap: 13px;
+`;
+
+const daengleMeter = css`
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+
+  margin-bottom: 32px;
+`;
+
+const textBox = css`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+`;
+
+const line = css`
+  height: 1px;
+
+  background-color: ${theme.colors.gray100};
+`;
+
+const bottomSection = css`
+  padding: 0 18px;
+`;
+
+const menu = css`
+  display: flex;
+  justify-content: space-between;
+
+  padding: 24px 0;
+
+  cursor: pointer;
+`;
+
+const review = css`
+  display: flex;
+  gap: 4px;
+`;

--- a/apps/daengle/src/pages/groomers/[groomerId]/index.tsx
+++ b/apps/daengle/src/pages/groomers/[groomerId]/index.tsx
@@ -1,0 +1,74 @@
+// 미용사 상세정보
+
+import { AppBar, Layout, Text, theme } from '@daengle/design-system';
+import { DefaultProfile } from '@daengle/design-system/icons';
+import { css } from '@emotion/react';
+
+export default function GroomerInfo() {
+  return (
+    <Layout>
+      <AppBar />
+      <Text typo="title1">상세보기</Text>
+      <section>
+        <div css={groomerProfile}>
+          <DefaultProfile width={101} height={117} css={imageStyle} />
+
+          <div css={infoBox}>
+            <Text typo="title2">문소연 디자이너</Text>
+            <div css={tags}>
+              <Text typo="body12" color="blue200" css={tag}>
+                #대형견
+              </Text>
+              <Text typo="body12" color="blue200" css={tag}>
+                #노견
+              </Text>
+            </div>
+            <div css={myShop}>
+              <Text typo="body9" color="gray500">
+                꼬꼬마 관리샵
+              </Text>
+            </div>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}
+
+const groomerProfile = css`
+  display: flex;
+  align-items: center;
+  gap: 15px;
+
+  width: 100%;
+  height: 153px;
+  border-bottom: 1px solid ${theme.colors.gray200};
+`;
+
+const imageStyle = css`
+  border-radius: 86px 86px 0 0;
+
+  background-color: ${theme.colors.gray200};
+`;
+
+const infoBox = css`
+  display: flex;
+  flex-direction: column;
+
+  margin-top: 25px;
+`;
+
+const tags = css`
+  display: flex;
+  gap: 6px;
+
+  margin: 6px 0 8px;
+`;
+
+const tag = css`
+  padding: 4px 12px;
+  border: 1px solid ${theme.colors.blue200};
+  border-radius: 14px;
+`;
+
+const myShop = css``;

--- a/apps/daengle/src/pages/shops/[groomerId]/index.tsx
+++ b/apps/daengle/src/pages/shops/[groomerId]/index.tsx
@@ -1,0 +1,5 @@
+// 미용샵 상세정보
+
+export default function ShopInfo() {
+  return <>미용사 상세정보</>;
+}

--- a/apps/daengle/src/pages/vets/[vetId]/index.tsx
+++ b/apps/daengle/src/pages/vets/[vetId]/index.tsx
@@ -1,0 +1,5 @@
+// 병원 상세정보
+
+export default function VetInfo() {
+  return <>병원 상세정보</>;
+}

--- a/packages/core/design-system/public/icons/tool_tip.svg
+++ b/packages/core/design-system/public/icons/tool_tip.svg
@@ -1,0 +1,5 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="7" cy="7" r="7" fill="#D9D9D9"/>
+<circle cx="6.99964" cy="4.45472" r="0.636364" fill="white"/>
+<rect x="6.36328" y="6.36328" width="1.27273" height="3.81818" rx="0.636364" fill="white"/>
+</svg>

--- a/packages/core/design-system/src/icons/ToolTip.tsx
+++ b/packages/core/design-system/src/icons/ToolTip.tsx
@@ -1,0 +1,8 @@
+import type { SVGProps } from 'react';
+export const ToolTip = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14" {...props}>
+    <circle cx={7} cy={7} r={7} fill="#D9D9D9" />
+    <circle cx={7} cy={4.455} r={0.636} fill="#fff" />
+    <rect width={1.273} height={3.818} x={6.363} y={6.363} fill="#fff" rx={0.636} />
+  </svg>
+);

--- a/packages/core/design-system/src/icons/index.ts
+++ b/packages/core/design-system/src/icons/index.ts
@@ -33,4 +33,5 @@ export * from './ReviewStarUnfilled';
 export * from './ReviewUnfold';
 export * from './SelectUnfoldActive';
 export * from './SelectUnfoldInactive';
+export * from './ToolTip';
 export * from './TransmissionComplete';


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #253 

<br/>

## 📝 관련 문서 레퍼런스

- [Slack] : X
- [Notion] : X

<br/>

## 💻 주요 변경 사항은 무엇인가요?

- 미용사 상세 정보 페이지 퍼블리싱

<br/>

## 📚 추가된 라이브러리

- [추가] : NO

<br/>

## 📱 결과 화면 (선택)
<img width="529" alt="스크린샷 2024-12-15 오후 7 00 32" src="https://github.com/user-attachments/assets/7ef4918e-5945-46d2-b087-f85db846bbb1" />

<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

-
