### PR TITLE
[Design/groomer] 미용사 예약 리스트 & 상세조회 퍼블리싱

### DIFF
--- a/apps/groomer/src/pages/reservations/[id]/index.tsx
+++ b/apps/groomer/src/pages/reservations/[id]/index.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+import 'dayjs/locale/ko';
+import { PetDetails, Section, UserProfile } from '@daengle/services/components';
+import { AppBar, Layout, RoundButton, Text, theme } from '@daengle/design-system';
+
+import { useRouter } from 'next/router';
+import { css } from '@emotion/react';
+
+import { GetGroomerEstimateDetailRequestParams } from '~/models/estimate';
+import { DatePick } from '~/components/estimate';
+import { ROUTES } from '~/constants';
+
+function requestDate(dateString: string): string {
+  const date = new Date(dateString);
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+}
+
+const petData = {
+  userImageUrl: '',
+  nickname: '닉네임',
+  address: '서울시 강남구 역삼동',
+  reservedDate: '2024-12-25 15:30:42',
+  petImageUrl: '',
+  petName: '감자',
+  age: 4,
+  weight: 'SMALL',
+  significant: '',
+  desiredStyle: '전체 가위컷',
+  requirements: '귀엽게 부탁드려요',
+  overallOpinion: '최고의 서비스로 모시겠습니다',
+};
+
+export default function EstimateDetail() {
+  const router = useRouter();
+
+  const { id } = router.query;
+  const estimateId = Number(id);
+  const [selectedDateTime, setSelectedDateTime] = useState<Dayjs | string>();
+  const petAttributes = [petData.age, petData.weight, petData.significant];
+
+  const handleDateTimeChange = (dateTime: Dayjs) => {
+    setSelectedDateTime(dateTime);
+  };
+
+  return (
+    <Layout>
+      <AppBar
+        backgroundColor={theme.colors.white}
+        onBackClick={() => router.back()}
+        onHomeClick={() => router.push(ROUTES.HOME)}
+      />
+      <div css={wrapper}>
+        <UserProfile userImage={petData.userImageUrl} userName={petData.nickname} />
+        <div css={sectionDivider}></div>
+        <div css={requestTitle}>
+          <Text typo="subtitle1">요청상세</Text>
+        </div>
+        <Section title="지역">{petData.address}</Section>
+        <Section title="시술 희망 날짜 및 시간">
+          <DatePick
+            onChange={handleDateTimeChange}
+            placeholderText={dayjs(petData.reservedDate)
+              .locale('ko')
+              .format('YYYY.MM.DD(ddd) • HH:mm')}
+            isEditable={false}
+          />
+        </Section>
+        <Section title="어떤 아이를 가꿀 예정이신가요?">
+          <PetDetails
+            image={petData.petImageUrl}
+            name={petData.petName}
+            attributes={petAttributes}
+          />
+        </Section>
+        <Section title="원하는 미용">{petData.desiredStyle}</Section>
+        <Section title="추가 요청사항">{petData.requirements}</Section>
+        <div css={sectionDivider}></div>
+        <Section title="안내사항">{petData.overallOpinion}</Section>
+        <div css={button}>
+          <RoundButton
+            service="partner"
+            size="L"
+            fullWidth
+            onClick={() => {
+              /* TODO:알람 전송 */
+            }}
+          >
+            미용 완료
+          </RoundButton>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+const wrapper = css`
+  height: 100vh;
+`;
+
+const sectionDivider = css`
+  display: block;
+
+  width: 100%;
+  height: 8px;
+  margin: 0;
+
+  background-color: ${theme.colors.gray100};
+`;
+
+const requestTitle = css`
+  padding: 24px 18px;
+`;
+
+const button = css`
+  padding: 24px 18px;
+`;

--- a/apps/groomer/src/pages/reservations/index.tsx
+++ b/apps/groomer/src/pages/reservations/index.tsx
@@ -1,16 +1,212 @@
-import { useRouter } from 'next/router';
-import { AppBar, Layout } from '@daengle/design-system';
-import { ROUTES } from '~/constants/commons';
+import { useState } from 'react';
+import { Text, Layout, theme } from '@daengle/design-system';
 import { GNB } from '~/components/commons';
+import { css } from '@emotion/react';
+
+const DATES: { id: number; day: keyof typeof RESERVATIONS; label: string }[] = [
+  { id: 1, day: '19', label: '월' },
+  { id: 2, day: '20', label: '화' },
+  { id: 3, day: '21', label: '수' },
+  { id: 4, day: '22', label: '목' },
+  { id: 5, day: '23', label: '금' },
+];
+
+const RESERVATIONS = {
+  '19': [
+    { time: '10:00', name: '꾸미', image: './profile1.jpg', description: '전체 가위컷' },
+    { time: '12:00', name: '장미', image: './profile2.jpg', description: '전체 클리핑 + 얼굴 컷' },
+    { time: '15:00', name: '가이', image: './profile3.jpg', description: '전체 클리핑' },
+    { time: '17:00', name: '강쥐', image: './profile4.jpg', description: '전체 클리핑 + 얼굴 컷' },
+  ],
+  '20': [{ time: '11:00', name: '초코', image: './profile5.jpg', description: '부분 가위컷' }],
+  '21': [],
+  '22': [
+    { time: '17:00', name: '강쥐', image: './profile4.jpg', description: '전체 클리핑 + 얼굴 컷' },
+  ],
+  '23': [
+    { time: '10:00', name: '꾸미', image: './profile1.jpg', description: '전체 가위컷' },
+    { time: '12:00', name: '장미', image: './profile2.jpg', description: '전체 클리핑 + 얼굴 컷' },
+    { time: '15:00', name: '가이', image: './profile3.jpg', description: '전체 클리핑' },
+    { time: '17:00', name: '강쥐', image: './profile4.jpg', description: '전체 클리핑 + 얼굴 컷' },
+  ],
+};
 
 export default function Reservations() {
-  const router = useRouter();
+  const [selectedDate, setSelectedDate] = useState<keyof typeof RESERVATIONS>('19');
 
   return (
-    <Layout>
-      <AppBar onBackClick={router.back} onHomeClick={() => router.push(ROUTES.HOME)} />
+    <Layout isAppBarExist={false}>
+      <div css={wrapper}>
+        <header css={headerContainer}>
+          <Text typo="title1">예약</Text>
+        </header>
+        <div css={calendar}>
+          <Text typo="title2">11월</Text>
+          <div css={dateTabs}>
+            {DATES.map((date) => (
+              <div
+                key={date.id}
+                css={dateTab(selectedDate === date.day)}
+                onClick={() => setSelectedDate(date.day)}
+              >
+                <Text typo="body8" color={selectedDate === date.day ? 'blue200' : 'gray500'}>
+                  {date.label}
+                </Text>
+                <div css={gap}></div>
+                <Text typo="title2" color={selectedDate === date.day ? 'blue200' : 'black'}>
+                  {date.day}
+                </Text>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div css={container}>
+          {RESERVATIONS[selectedDate]?.map((item, index) => {
+            const isLast = index === RESERVATIONS[selectedDate].length - 1; // 마지막 요소 판단
+            return (
+              <div key={index} css={timeline}>
+                <div css={dot(isLast)}></div> {/* 마지막 점인지 전달 */}
+                <span css={time}>{item.time}</span>
+                <div css={content}>
+                  <img src={item.image} alt="profile" css={profileImage} />
+                  <Text typo="subtitle3">{item.name}</Text>
+                  <div css={desiredStyle}>
+                    <Text typo="body10" css={description}>
+                      {item.description}
+                    </Text>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
 
       <GNB />
     </Layout>
   );
 }
+
+const wrapper = css`
+  height: 100vh;
+  padding-bottom: 104px;
+
+  background-color: ${theme.colors.background};
+`;
+
+const headerContainer = css`
+  margin-top: 20px;
+  padding: 18px;
+`;
+
+const calendar = css`
+  padding: 16px 18px 0;
+`;
+
+const dateTabs = css`
+  display: flex;
+  justify-content: space-between;
+
+  margin-top: 12px;
+  padding: 0 18px;
+`;
+const gap = css`
+  padding: 4px;
+`;
+
+const dateTab = (isActive: boolean) => css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  padding: 20px 19px;
+  border-bottom: ${isActive ? `2px solid ${theme.colors.blue200}` : 'none'};
+
+  cursor: pointer;
+`;
+
+const container = css`
+  margin-top: 24px;
+  padding: 0 18px;
+`;
+
+const dot = (isLast: boolean) => css`
+  position: relative;
+
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+
+  background-color: #4ac0ef;
+
+  ${!isLast &&
+  `
+    &::after {
+      content: '';
+      position: absolute;
+      top: 18px; /* 점 바로 밑에서 시작 */
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 0;
+
+      width: 1px; /* 점선 두께 */
+      height: calc(100% + 40px); /* 점선 길이 */
+
+      background-image: linear-gradient(to bottom, black 50%, transparent 50%);
+      background-size: 1px 8px; /* 점선 간격 */
+      background-repeat: repeat-y;
+    }
+  `}
+`;
+
+const timeline = css`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  position: relative;
+
+  min-height: 60px; /* 컨테이너에 최소 높이 추가 */
+  margin-bottom: 16px;
+
+  /* 마지막 타임라인의 점선 제거 */
+  &:last-child .dot::after {
+    content: none;
+  }
+`;
+
+const time = css`
+  color: ${theme.colors.gray500};
+  font-size: 14px;
+`;
+
+const content = css`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: 8px;
+
+  border-radius: 50px;
+
+  background-color: ${theme.colors.white};
+`;
+
+const profileImage = css`
+  width: 40px;
+  height: 40px;
+  margin: 8px;
+  border-radius: 50%;
+`;
+
+const description = css`
+  margin: 21px 24px;
+
+  color: ${theme.colors.gray500};
+  font-size: 12px;
+`;
+
+const desiredStyle = css`
+  display: flex;
+  flex: 1;
+  justify-content: flex-end;
+`;


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #321 

<br/>

## 📝 관련 문서 레퍼런스

- [Slack] : X
- [Notion] : https://www.notion.so/981021/1592efd96e69803987d7ca84cfae1504?pvs=4#2a35b331afe348ea8941241e04a9b391

<br/>

## 💻 주요 변경 사항은 무엇인가요?

- 미용사가 조회하는 예약 리스트 화면과 예약 상세 화면을 구현하였습니다

<br/>

## 📚 추가된 라이브러리

- [추가] :NO

<br/>

## 📱 결과 화면 (선택)
<img width="200" alt="스크린샷 2024-12-17 오전 1 27 45" src="https://github.com/user-attachments/assets/48f71950-3d76-4c6c-a2be-3a56ebc9b070" />
<img width="200" alt="스크린샷 2024-12-17 오전 1 08 51" src="https://github.com/user-attachments/assets/0f682302-7566-47b6-8641-c923c035aa02" />

<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

-
