### PR TITLE
[Feature/daengle] 사용자 예약 리스트 & 상세 조회 api 연동

### DIFF
--- a/apps/daengle/src/components/estimate/card-list/index.tsx
+++ b/apps/daengle/src/components/estimate/card-list/index.tsx
@@ -14,6 +14,7 @@ import {
 } from './index.styles';
 import { DefaultProfile } from '@daengle/design-system/icons';
 import { UserEstimateGeneralGroomingType } from '~/interfaces/estimate';
+import dayjs from 'dayjs';
 
 interface Props {
   mode: 'general' | 'designation';
@@ -52,7 +53,7 @@ export function CardList({ mode, category, estimateData, onCardClick }: Props): 
                 {item.shopName || (category === 'vet' ? '' : '미용실 정보 없음')}
               </Text>
               <Text typo="body12" color="gray600">
-                {item.reservedDate}
+                {dayjs(item.reservedDate).locale('ko').format('YYYY.MM.DD(ddd) • HH:mm')}
               </Text>
               <div css={tagsContainer}>
                 {item.keywords?.map((keyword) => (

--- a/apps/daengle/src/components/reservations/reservations-card/index.tsx
+++ b/apps/daengle/src/components/reservations/reservations-card/index.tsx
@@ -31,7 +31,7 @@ interface VetItem {
 export function ReservationsCard({ item }: Props) {
   const router = useRouter();
 
-  const isGroomer = (item: GroomerItem | VetItem): item is GroomerItem => 'groomerId' in item;
+  const isGroomer = (item: GroomerItem | VetItem): item is GroomerItem => 'groomerName' in item;
 
   return (
     <div css={wrapper} onClick={() => router.push(ROUTES.RESERVATIONS_DETAIL(item.estimateId))}>

--- a/apps/daengle/src/models/reservation/index.ts
+++ b/apps/daengle/src/models/reservation/index.ts
@@ -13,6 +13,7 @@ export interface GetUserReservationGroomingDetailRequestParams {
 }
 
 export interface GetUserReservationGroomingDetailResponse {
+  reservationId: number;
   groomingEstimateId: number;
   groomerId: number;
   imageUrl: string;
@@ -34,6 +35,7 @@ export interface GetUserReservationCareDetailRequestParams {
 }
 
 export interface GetUserReservationCareDetailResponse {
+  reservationId: number;
   careEstimateId: number;
   vetId: number;
   imageUrl: string;

--- a/apps/daengle/src/pages/estimates/index.tsx
+++ b/apps/daengle/src/pages/estimates/index.tsx
@@ -20,29 +20,18 @@ const TABS = [
 ];
 export default function EstimateList() {
   const router = useRouter();
-  const { tab, isDesignation: isDesignationQuery } = router.query;
+  const { service, isDesignation: isDesignationQuery } = router.query;
   const isDesignation = isDesignationQuery === 'true';
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
-    if (router.isReady && !tab) {
+    if (router.isReady && !service) {
       router.replace({
         pathname: '/estimates',
-        query: { tab: 'groomer', isDesignation: 'false' },
+        query: { service: 'groomer', isDesignation: 'false' },
       });
     }
   }, [router.isReady]);
-
-  const handleTabChange = (activeTabId: string) => {
-    router.push(
-      {
-        pathname: '/estimates',
-        query: { tab: activeTabId, isDesignation: isDesignationQuery },
-      },
-      undefined,
-      { shallow: true }
-    );
-  };
 
   const renderContent = (activeTabId: string) => {
     switch (activeTabId) {

--- a/apps/daengle/src/pages/reservations/[id]/index.tsx
+++ b/apps/daengle/src/pages/reservations/[id]/index.tsx
@@ -21,11 +21,11 @@ type DetailData = GetUserReservationGroomingDetailResponse | GetUserReservationC
 
 export default function Detail() {
   const router = useRouter();
-  const { id, tab } = router.query;
+  const { id, service } = router.query;
   const estimateId = Number(id);
 
-  const isGrooming = tab === 'groomer';
-  const isCare = tab === 'vet';
+  const isGrooming = service === 'groomer';
+  const isCare = service === 'vet';
 
   const groomingParams: GetUserReservationGroomingDetailRequestParams = {
     estimateId: estimateId,

--- a/apps/daengle/src/pages/reservations/[id]/index.tsx
+++ b/apps/daengle/src/pages/reservations/[id]/index.tsx
@@ -16,6 +16,7 @@ import {
   useUserReservationCareDetailQuery,
   useUserReservationGroomingDetailQuery,
 } from '~/queries/reservation';
+import { ROUTES } from '~/constants/commons';
 
 type DetailData = GetUserReservationGroomingDetailResponse | GetUserReservationCareDetailResponse;
 
@@ -78,12 +79,21 @@ export default function Detail() {
 
     return (
       <Layout isAppBarExist={false}>
-        <AppBar />
+        <AppBar
+          backgroundColor={theme.colors.background}
+          onBackClick={() => {
+            router.back;
+          }}
+          onHomeClick={() => router.push(ROUTES.HOME)}
+        />
         <div css={wrapper}>
           <div css={header}>
             <Text typo="title1">견적 상세</Text>
           </div>
-          <PartnersInfo profile={designerData} />
+          <PartnersInfo
+            profile={designerData}
+            onClick={() => router.push(ROUTES.GROOMER_SHOP_DETAIL(detailData.shopId))}
+          />
           <section css={section}>
             <Text typo="body1">소개</Text>
             <Text typo="body10" tag="div">
@@ -128,7 +138,13 @@ export default function Detail() {
     };
     return (
       <Layout isAppBarExist={false}>
-        <AppBar />
+        <AppBar
+          backgroundColor={theme.colors.background}
+          onBackClick={() => {
+            router.back;
+          }}
+          onHomeClick={() => router.push(ROUTES.HOME)}
+        />
         <div css={wrapper}>
           <div css={header}>
             <Text typo="title1">진료 상세</Text>
@@ -144,7 +160,7 @@ export default function Detail() {
             items={[
               { title: '지역', receipt: detailData.address },
               { title: '일정', receipt: formattedDate, hasLine: true, addTitle: '종합소견' },
-              { title: '추정 병명', receipt: detailData.cause },
+              { title: '추정 병명', receipt: detailData.diagnosis },
               { title: '추정 원인', receipt: detailData.cause },
               {
                 title: '예상 진료',

--- a/apps/daengle/src/pages/reservations/index.tsx
+++ b/apps/daengle/src/pages/reservations/index.tsx
@@ -28,14 +28,6 @@ export default function Reservations() {
     }
   };
 
-  const { tab = 'groomer' } = router.query;
-
-  const handleTabChange = (activeTabId: string) => {
-    router.push({ pathname: '/reservations', query: { tab: activeTabId } }, undefined, {
-      shallow: true,
-    });
-  };
-
   return (
     <Layout isAppBarExist={false}>
       <section css={wrapper}>

--- a/apps/daengle/src/pages/reservations/index.tsx
+++ b/apps/daengle/src/pages/reservations/index.tsx
@@ -28,6 +28,14 @@ export default function Reservations() {
     }
   };
 
+  const { tab = 'groomer' } = router.query;
+
+  const handleTabChange = (activeTabId: string) => {
+    router.push({ pathname: '/reservations', query: { tab: activeTabId } }, undefined, {
+      shallow: true,
+    });
+  };
+
   return (
     <Layout isAppBarExist={false}>
       <section css={wrapper}>


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #274 

<br/>

## 📝 관련 문서 레퍼런스

- [Slack] : X
- [Notion] : https://www.notion.so/981021/1592efd96e69803987d7ca84cfae1504?pvs=4#2a35b331afe348ea8941241e04a9b391

<br/>

## 💻 주요 변경 사항은 무엇인가요?

- 사용자가 결제한 견적서건에 대하여 예약 페이지에서 확인할 수 있습니다

<br/>

## 📚 추가된 라이브러리

- [추가] :  NO

<br/>

## 📱 결과 화면 (선택)
<img width="200" alt="스크린샷 2024-12-17 오전 10 49 26" src="https://github.com/user-attachments/assets/e7e875ff-c5f6-4240-a530-bb54c79e0db5" />
<img width="200" alt="스크린샷 2024-12-17 오전 10 49 35" src="https://github.com/user-attachments/assets/ef078446-d87f-417a-8c47-43566f6582db" />

<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

- 현재 DB 문제로 인해 예약 상세 페이지가 조회가 안됩니다. (연동은 완료하였습니다)
