### PR TITLE
[Feature/design-system] useToast useDialog 훅 구현

### DIFF
--- a/apps/daengle/src/pages/_app.tsx
+++ b/apps/daengle/src/pages/_app.tsx
@@ -1,16 +1,18 @@
 import type { AppProps } from 'next/app';
-import { GlobalStyle, DialogProvider } from '@daengle/design-system';
+import { GlobalStyle, DialogProvider, ToastProvider } from '@daengle/design-system';
 import { QueryProvider } from '@daengle/services/providers';
 import { initMSW } from '~/mocks/init-msw';
 
 initMSW();
 
-export default function MyApp({ Component, pageProps }: AppProps & { isAppBarExist?: boolean }) {
+export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <QueryProvider>
       <GlobalStyle>
         <DialogProvider>
-          <Component {...pageProps} />
+          <ToastProvider>
+            <Component {...pageProps} />
+          </ToastProvider>
         </DialogProvider>
       </GlobalStyle>
     </QueryProvider>

--- a/apps/daengle/src/pages/_app.tsx
+++ b/apps/daengle/src/pages/_app.tsx
@@ -1,5 +1,5 @@
 import type { AppProps } from 'next/app';
-import { GlobalStyle } from '@daengle/design-system';
+import { GlobalStyle, DialogProvider } from '@daengle/design-system';
 import { QueryProvider } from '@daengle/services/providers';
 import { initMSW } from '~/mocks/init-msw';
 
@@ -9,7 +9,9 @@ export default function MyApp({ Component, pageProps }: AppProps & { isAppBarExi
   return (
     <QueryProvider>
       <GlobalStyle>
-        <Component {...pageProps} />
+        <DialogProvider>
+          <Component {...pageProps} />
+        </DialogProvider>
       </GlobalStyle>
     </QueryProvider>
   );

--- a/apps/daengle/src/pages/_document.tsx
+++ b/apps/daengle/src/pages/_document.tsx
@@ -1,8 +1,7 @@
 import { Html, Head, Main, NextScript } from 'next/document';
-
 export default function Document() {
   return (
-    <Html lang="en">
+    <Html lang="ko">
       <Head />
       <body>
         <Main />

--- a/apps/daengle/src/pages/index.tsx
+++ b/apps/daengle/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { AppBar, Dialog, Layout, RoundButton, Tabs, Text, theme } from '@daengle/design-system';
+import { AppBar, Layout, RoundButton, Tabs, Text, theme, useDialog } from '@daengle/design-system';
 import { MainLogo, SearchIcon, SelectUnfoldInactive } from '@daengle/design-system/icons';
 import { DaengleDog } from '@daengle/design-system/images';
 import { css } from '@emotion/react';
@@ -30,13 +30,22 @@ export default function Home() {
   const { data: getUserValidate } = useGetUserValidateQuery();
   const { addressForm } = useAddressFormStore();
 
+  const { open } = useDialog();
+
   const handleSearchAddress = () => {
+    open({
+      title: '로그인 후 이용해 주세요',
+      primaryActionLabel: '로그인 하기',
+      onPrimaryAction: () => router.push(ROUTES.LOGIN),
+    });
     if (getUserValidate) {
       router.push(ROUTES.SEARCH_ADDRESS);
     } else {
-      // TODO: 모달창으로 변경
-      alert('로그인 해주세요');
-      router.push(ROUTES.LOGIN);
+      open({
+        title: '로그인 후 이용해 주세요',
+        primaryActionLabel: '로그인 하기',
+        onPrimaryAction: () => router.push(ROUTES.LOGIN),
+      });
     }
   };
 
@@ -44,9 +53,11 @@ export default function Home() {
     if (getUserValidate) {
       setIsVisible(true);
     } else {
-      // TODO: 모달창으로 변경
-      alert('로그인 해주세요');
-      router.push(ROUTES.LOGIN);
+      open({
+        title: '로그인 후 이용해 주세요',
+        primaryActionLabel: '로그인 하기',
+        onPrimaryAction: () => router.push(ROUTES.LOGIN),
+      });
     }
   };
 

--- a/apps/groomer/src/pages/_app.tsx
+++ b/apps/groomer/src/pages/_app.tsx
@@ -1,5 +1,5 @@
 import type { AppProps } from 'next/app';
-import { GlobalStyle } from '@daengle/design-system';
+import { DialogProvider, GlobalStyle, ToastProvider } from '@daengle/design-system';
 import { QueryProvider } from '@daengle/services/providers';
 import { initMSW } from '~/mocks/init-msw';
 
@@ -9,7 +9,11 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <QueryProvider>
       <GlobalStyle>
-        <Component {...pageProps} />
+        <DialogProvider>
+          <ToastProvider>
+            <Component {...pageProps} />
+          </ToastProvider>
+        </DialogProvider>
       </GlobalStyle>
     </QueryProvider>
   );

--- a/apps/groomer/src/pages/_document.tsx
+++ b/apps/groomer/src/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+export default function Document() {
+  return (
+    <Html lang="ko">
+      <Head />
+      <body>
+        <Main />
+        <div id="portal-container" />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/apps/vet/src/pages/_app.tsx
+++ b/apps/vet/src/pages/_app.tsx
@@ -1,5 +1,5 @@
 import type { AppProps } from 'next/app';
-import { GlobalStyle } from '@daengle/design-system';
+import { DialogProvider, GlobalStyle, ToastProvider } from '@daengle/design-system';
 import { QueryProvider } from '@daengle/services/providers';
 import { initMSW } from '~/mocks/init-msw';
 
@@ -9,7 +9,11 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <QueryProvider>
       <GlobalStyle>
-        <Component {...pageProps} />
+        <DialogProvider>
+          <ToastProvider>
+            <Component {...pageProps} />
+          </ToastProvider>
+        </DialogProvider>
       </GlobalStyle>
     </QueryProvider>
   );

--- a/apps/vet/src/pages/_document.tsx
+++ b/apps/vet/src/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+export default function Document() {
+  return (
+    <Html lang="ko">
+      <Head />
+      <body>
+        <Main />
+        <div id="portal-container" />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/packages/core/design-system/src/components/dialog/index.styles.ts
+++ b/packages/core/design-system/src/components/dialog/index.styles.ts
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { SecondaryActionType } from '.';
 import { theme } from '../../foundation';
 
 export const wrapper = css`
@@ -53,20 +52,4 @@ export const button = css`
   & + & {
     border-left: 1px solid ${theme.colors.gray100};
   }
-`;
-
-export const secondaryButton = ({
-  secondaryActionType,
-}: {
-  secondaryActionType: SecondaryActionType;
-}) => css`
-  ${secondaryActionType === 'neutral' &&
-  css`
-    background: ${theme.colors.gray200};
-    color: ${theme.colors.white};
-
-    &:hover {
-      background: ${theme.colors.gray300};
-    }
-  `}
 `;

--- a/packages/core/design-system/src/components/dialog/index.tsx
+++ b/packages/core/design-system/src/components/dialog/index.tsx
@@ -1,5 +1,5 @@
 import { createContext, HTMLAttributes, ReactNode } from 'react';
-import { button, buttonWrapper, secondaryButton, text, wrapper } from './index.styles';
+import { button, buttonWrapper, text, wrapper } from './index.styles';
 import { Text } from '../text';
 import { Dim } from '../dim';
 import { Portal } from '../portal';

--- a/packages/core/design-system/src/components/dialog/index.tsx
+++ b/packages/core/design-system/src/components/dialog/index.tsx
@@ -1,37 +1,38 @@
-import { HTMLAttributes } from 'react';
+import { createContext, HTMLAttributes, ReactNode } from 'react';
 import { button, buttonWrapper, secondaryButton, text, wrapper } from './index.styles';
 import { Text } from '../text';
 import { Dim } from '../dim';
 import { Portal } from '../portal';
 
-export type DialogType = 'action' | 'error';
-export type SecondaryActionType = 'neutral';
+interface DialogContext {
+  open: (content: ReactNode) => void;
+  close: () => void;
+}
+const DialogContext = createContext<DialogContext | null>(null);
 
 export interface DialogProps extends HTMLAttributes<HTMLDivElement> {
-  type?: DialogType;
   title: string;
   description?: string;
   primaryActionLabel: string;
   secondaryActionLabel?: string;
-  secondaryActionType?: SecondaryActionType;
   onPrimaryAction?: () => void;
   onSecondaryAction?: () => void;
+  onClose?: () => void;
 }
 
 export function Dialog({
-  type = 'action',
   title,
   description,
   primaryActionLabel,
   secondaryActionLabel,
-  secondaryActionType = 'neutral',
   onPrimaryAction,
   onSecondaryAction,
+  onClose,
   ...props
 }: DialogProps) {
   return (
     <Portal>
-      <Dim fullScreen />
+      <Dim fullScreen onClick={onClose} />
 
       <div {...props} css={wrapper}>
         <div css={text}>

--- a/packages/core/design-system/src/components/toast/index.tsx
+++ b/packages/core/design-system/src/components/toast/index.tsx
@@ -5,14 +5,14 @@ import { Text } from '../text';
 import { Portal } from '../portal';
 import { toast } from './index.styles';
 
-interface Props {
+export interface ToastProps {
   isShow: boolean;
   title: string;
   time?: number;
   service?: 'daengle' | 'partner';
 }
 
-export function Toast({ isShow, title, time = 3000, service = 'daengle' }: Props) {
+export function Toast({ isShow, title, time = 3000, service = 'daengle' }: ToastProps) {
   const [isOpen, setIsOpen] = useState<boolean>(isShow);
 
   useEffect(() => {

--- a/packages/core/design-system/src/hooks/index.ts
+++ b/packages/core/design-system/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './use-dialog';
+export * from './use-toast';

--- a/packages/core/design-system/src/hooks/index.ts
+++ b/packages/core/design-system/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-dialog';

--- a/packages/core/design-system/src/hooks/use-dialog/index.tsx
+++ b/packages/core/design-system/src/hooks/use-dialog/index.tsx
@@ -51,10 +51,6 @@ export function DialogProvider({ children }: { children: ReactNode }) {
 
 export const useDialog = () => {
   const context = useContext(DialogContext);
-
-  if (!context) {
-    throw new Error('useDialog must be used within a DialogProvider');
-  }
-
+  if (!context) throw new Error('useDialog 에러');
   return context;
 };

--- a/packages/core/design-system/src/hooks/use-dialog/index.tsx
+++ b/packages/core/design-system/src/hooks/use-dialog/index.tsx
@@ -1,0 +1,60 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { Dialog, type DialogProps } from '../../components/dialog';
+
+interface DialogContextType {
+  open: (
+    props: Omit<DialogProps, 'onPrimaryAction' | 'onSecondaryAction'> & {
+      onPrimaryAction?: () => void;
+      onSecondaryAction?: () => void;
+    }
+  ) => void;
+  close: () => void;
+}
+
+const DialogContext = createContext<DialogContextType | null>(null);
+
+export function DialogProvider({ children }: { children: ReactNode }) {
+  const [dialogProps, setDialogProps] = useState<(DialogProps & { isOpen: boolean }) | null>(null);
+
+  const open = (props: DialogProps) => {
+    setDialogProps({ ...props, isOpen: true });
+  };
+
+  const close = () => {
+    setDialogProps((prev) => (prev ? { ...prev, isOpen: false } : null));
+  };
+
+  return (
+    <DialogContext.Provider value={{ open, close }}>
+      {children}
+
+      {dialogProps?.isOpen && (
+        <Dialog
+          title={dialogProps.title}
+          description={dialogProps.description}
+          primaryActionLabel={dialogProps.primaryActionLabel}
+          secondaryActionLabel={dialogProps.secondaryActionLabel}
+          onPrimaryAction={() => {
+            dialogProps.onPrimaryAction?.();
+            close();
+          }}
+          onSecondaryAction={() => {
+            dialogProps.onSecondaryAction?.();
+            close();
+          }}
+          onClose={close}
+        />
+      )}
+    </DialogContext.Provider>
+  );
+}
+
+export const useDialog = () => {
+  const context = useContext(DialogContext);
+
+  if (!context) {
+    throw new Error('useDialog must be used within a DialogProvider');
+  }
+
+  return context;
+};

--- a/packages/core/design-system/src/hooks/use-toast/index.tsx
+++ b/packages/core/design-system/src/hooks/use-toast/index.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { Toast, ToastProps } from '../../components/toast';
+
+interface ToastContextType {
+  showToast: (props: Omit<ToastProps, 'isShow'>) => void;
+}
+
+const ToastContext = createContext<ToastContextType | null>(null);
+
+export const ToastProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [toastProps, setToastProps] = useState<ToastProps | null>(null);
+
+  const showToast = ({ title, time, service }: Omit<ToastProps, 'isShow'>) => {
+    setToastProps({ isShow: true, title, time, service });
+
+    setTimeout(() => {
+      setToastProps((prev) => (prev ? { ...prev, isShow: false } : null));
+    }, time || 4000);
+  };
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+
+      {toastProps?.isShow && (
+        <Toast
+          isShow={toastProps.isShow}
+          title={toastProps.title}
+          time={toastProps.time}
+          service={toastProps.service}
+        />
+      )}
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) throw new Error('useToast 에러');
+  return context;
+};

--- a/packages/core/design-system/src/index.ts
+++ b/packages/core/design-system/src/index.ts
@@ -1,2 +1,3 @@
 export * from './components';
+export * from './hooks';
 export * from './foundation';


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #363 

<br/>

## 📝 관련 문서 레퍼런스

- [Slack] : X
- [Notion] : X

<br/>

## 💻 주요 변경 사항은 무엇인가요?

- useToast 훅을 구현했습니다
- useDialog 훅을 구현했습니다

<br/>

## 📚 추가된 라이브러리

- [추가] : NO

<br/>

## 📱 결과 화면 (선택)

<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

- useToast 사용 방법
```typescript
const { showToast } = useToast();
open({ title: "리뷰가 삭제되었습니다" });
```
- useDialog 사용 방법
```typescript
const { open } = useDialog();
open({ title: "로그인 후 이용해 주세요", onPrimaryActionLabel: "로그인 하기", onPrimaryAction: () => router.push('/') });
```
