### PR TITLE
[Design/groomer] 미용샵(마이샵) 상세 페이지 퍼블리싱

### DIFF
--- a/apps/groomer/src/components/mypage/profile-card/index.styles.ts
+++ b/apps/groomer/src/components/mypage/profile-card/index.styles.ts
@@ -1,0 +1,48 @@
+import { theme } from '@daengle/design-system';
+import { css } from '@emotion/react';
+
+export const profileCard = css`
+  display: flex;
+  gap: 20px;
+
+  padding: 15px 0;
+  border-bottom: 1px solid ${theme.colors.gray100};
+`;
+
+export const imageStyle = css`
+  border-radius: 86px 86px 0 0;
+
+  background-color: ${theme.colors.gray200};
+`;
+
+export const profile = css`
+  margin-top: 32px;
+`;
+
+export const tags = css`
+  display: flex;
+  gap: 6px;
+
+  margin: 6px 0 8px;
+`;
+
+export const meterTag = css`
+  display: flex;
+  align-items: center;
+
+  padding: 4px 12px;
+  border-radius: 14px;
+
+  background-color: ${theme.colors.red100};
+`;
+
+export const tag = css`
+  padding: 4px 12px;
+  border: 1px solid ${theme.colors.blue200};
+  border-radius: 14px;
+`;
+
+export const paw = css`
+  margin-right: 1px;
+  fill: ${theme.colors.red200};
+`;

--- a/apps/groomer/src/components/mypage/profile-card/index.tsx
+++ b/apps/groomer/src/components/mypage/profile-card/index.tsx
@@ -1,0 +1,26 @@
+import { DefaultProfile, Paw } from '@daengle/design-system/icons';
+import { imageStyle, meterTag, profile, profileCard, tag, tags, paw } from './index.styles';
+import { Text } from '@daengle/design-system';
+
+export default function ProfileCard() {
+  return (
+    <div css={profileCard}>
+      <DefaultProfile width={80} height={94} css={imageStyle} />
+      <div css={profile}>
+        <Text typo="subtitle3">김윤일 디자이너</Text>
+        <div css={tags}>
+          <Text typo="body2" color="red200" css={meterTag}>
+            <Paw width={9} css={paw} />
+            39m
+          </Text>
+          <Text typo="body12" color="blue200" css={tag}>
+            #대형견
+          </Text>
+          <Text typo="body12" color="blue200" css={tag}>
+            #노견
+          </Text>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/groomer/src/pages/mypage/shop/[id]/index.tsx
+++ b/apps/groomer/src/pages/mypage/shop/[id]/index.tsx
@@ -1,0 +1,147 @@
+import { AppBar, Layout, Text, theme } from '@daengle/design-system';
+import { DetailCall, DetailLocation, DetailTime } from '@daengle/design-system/icons';
+import { ShopDefaultImage } from '@daengle/design-system/images';
+import { css } from '@emotion/react';
+import { useRouter } from 'next/router';
+import ProfileCard from '~/components/mypage/profile-card';
+import { ROUTES } from '~/constants';
+
+export default function GroomerMyShopInfo() {
+  const router = useRouter();
+  return (
+    <Layout isAppBarExist={false}>
+      <AppBar onBackClick={router.back} onHomeClick={() => router.push(ROUTES.HOME)} />
+      <div css={wrapper}>
+        <div css={imageSection}>
+          <ShopDefaultImage />
+          <Text typo="title2" color="white" css={shopName}>
+            꼬꼬마 관리샵
+          </Text>
+        </div>
+        <div css={infoBox}>
+          <section css={topSection}>
+            <section css={infoSection}>
+              <div css={time}>
+                <DetailTime width={20} />
+                <Text typo="body9">매일 00:00 - 23:59</Text>
+              </div>
+              <div css={call}>
+                <DetailCall width={20} />
+                <Text typo="body9">02-000-0000</Text>
+              </div>
+              <div css={address}>
+                <DetailLocation width={20} />
+                <Text typo="body9">서울시 강남구 역삼동</Text>
+              </div>
+            </section>
+            <div css={line} />
+            <section css={infoText}>
+              <Text typo="body1">소개</Text>
+              <Text typo="body10">소개글</Text>
+            </section>
+          </section>
+          <section css={bottomSection}>
+            <div css={textBox}>
+              <Text typo="title2">디자이너</Text>
+              <Text typo="title2">1</Text>
+            </div>
+            <section css={groomerList}>
+              <ProfileCard />
+            </section>
+          </section>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+const wrapper = css`
+  position: relative;
+
+  width: 100%;
+  height: 100%;
+`;
+
+const imageSection = css`
+  position: relative;
+
+  width: 100%;
+  height: 416px;
+`;
+
+const shopName = css`
+  position: absolute;
+  bottom: 180px;
+  left: 24px;
+`;
+
+const infoBox = css`
+  position: absolute;
+  bottom: 0;
+
+  width: 100%;
+  height: 540px;
+  border-radius: 20px 20px 0 0;
+
+  background-color: white;
+`;
+
+const topSection = css`
+  padding: 32px 18px 0;
+
+  border-bottom: 7px solid ${theme.colors.gray100};
+`;
+
+const infoSection = css`
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+`;
+
+const time = css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+const call = css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+const address = css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  margin-bottom: 24px;
+`;
+
+const line = css`
+  height: 1px;
+
+  background-color: ${theme.colors.gray100};
+`;
+
+const infoText = css`
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+
+  margin-bottom: 32px;
+  padding-top: 24px;
+`;
+
+const bottomSection = css`
+  padding: 24px 18px 0;
+`;
+
+const textBox = css`
+  display: flex;
+  gap: 4px;
+
+  margin-bottom: 9px;
+`;
+
+const groomerList = css`
+  cursor: pointer;
+`;

--- a/packages/core/design-system/src/components/app-bar/index.styles.ts
+++ b/packages/core/design-system/src/components/app-bar/index.styles.ts
@@ -23,11 +23,7 @@ export const contents = css`
 
   width: 100%;
   height: 100%;
-
-  /* AppBar 없는 경우 padding 값 18px로 변경(논의 필요) */
-
-  /* padding: 0 12px 0 8px; */
-  padding: 18px;
+  padding: 0 12px 0 8px;
 
   #title {
     position: absolute;


### PR DESCRIPTION
## 🍡 연관된 이슈 번호

- close #396 

<br/>

## 📝 관련 문서 레퍼런스

- [Slack] : x
- [Notion] : x

<br/>

## 💻 주요 변경 사항은 무엇인가요?

- 미용사의 미용샵 상세 정보 페이지 퍼블리싱

<br/>

## 📚 추가된 라이브러리

- [추가] : NO

<br/>

## 📱 결과 화면 (선택)
<img width="477" alt="스크린샷 2024-12-18 오후 8 40 06" src="https://github.com/user-attachments/assets/efd7d3a8-25b4-4ec6-ac77-6b2e4858bc16" />
<img width="477" alt="스크린샷 2024-12-18 오후 8 29 53" src="https://github.com/user-attachments/assets/4267af2e-8ccd-4656-9c95-4286e68c1424" />

<br/>

## 🙇 코드 리뷰 중점사항, 예상되는 문제점 (선택)

-
